### PR TITLE
fix(ci): Node 22 for pnpm 11

### DIFF
--- a/.github/workflows/validate-and-deploy.yml
+++ b/.github/workflows/validate-and-deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for Chores & Rewards PWA
-FROM node:20-alpine
+FROM node:22-alpine
 
 # Install curl for health checks
 RUN apk add --no-cache curl


### PR DESCRIPTION
The pnpm migration (#25) failed in CI: pnpm 11 requires Node ≥22.13, but the workflow and Docker base image pinned Node 20. Bumps both to 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)