### PR TITLE
fix(ci): approve build scripts for pnpm 11

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
 overrides:
   # 2026-07-05 sweep: esbuild-kit (deprecated, inside drizzle-kit) pins esbuild ~0.18.
   "esbuild@<=0.24.2": ^0.25.0
+
+allowBuilds:
+  bufferutil: true
+  esbuild: true


### PR DESCRIPTION
Third and final piece of the pnpm migration: pnpm 11 hard-fails CI installs on unapproved dependency build scripts (bufferutil, esbuild). Adds allowBuilds to pnpm-workspace.yaml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)