### PR TITLE
fix(ui): aria-labels, honest stats card, drop fabricated counts

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -70,7 +70,7 @@ function AppContent() {
                 location === '/' 
                   ? 'bg-white text-brand-coral shadow-soft' 
                   : 'text-brand-grayDark hover:bg-white/70'
-              }`} data-testid="nav-home">
+              }`} aria-label="Home" data-testid="nav-home">
                 <Users className="w-4 h-4" />
                 <span className="font-medium text-xs sm:text-sm hidden sm:inline">Home</span>
               </button>
@@ -80,7 +80,7 @@ function AppContent() {
                 location === '/totals' 
                   ? 'bg-white text-brand-coral shadow-soft' 
                   : 'text-brand-grayDark hover:bg-white/70'
-              }`} data-testid="nav-totals">
+              }`} aria-label="Totals" data-testid="nav-totals">
                 <DollarSign className="w-4 h-4" />
                 <span className="font-medium text-xs sm:text-sm hidden sm:inline">Totals</span>
               </button>
@@ -90,7 +90,7 @@ function AppContent() {
                 location === '/chores' 
                   ? 'bg-white text-brand-coral shadow-soft' 
                   : 'text-brand-grayDark hover:bg-white/70'
-              }`} data-testid="nav-chores">
+              }`} aria-label="Chores" data-testid="nav-chores">
                 <ListTodo className="w-4 h-4" />
                 <span className="font-medium text-xs sm:text-sm hidden sm:inline">Chores</span>
               </button>
@@ -100,7 +100,7 @@ function AppContent() {
                 location === '/history' 
                   ? 'bg-white text-brand-coral shadow-soft' 
                   : 'text-brand-grayDark hover:bg-white/70'
-              }`} data-testid="nav-history">
+              }`} aria-label="History" data-testid="nav-history">
                 <History className="w-4 h-4" />
                 <span className="font-medium text-xs sm:text-sm hidden sm:inline">History</span>
               </button>
@@ -110,7 +110,7 @@ function AppContent() {
                 location === '/settings' 
                   ? 'bg-white text-brand-coral shadow-soft' 
                   : 'text-brand-grayDark hover:bg-white/70'
-              }`} data-testid="nav-settings">
+              }`} aria-label="Settings" data-testid="nav-settings">
                 <Settings className="w-4 h-4" />
               </button>
             </Link>

--- a/client/src/pages/ChildChoresPage.tsx
+++ b/client/src/pages/ChildChoresPage.tsx
@@ -157,6 +157,7 @@ export default function ChildChoresPage({ childId }: ChildChoresPageProps) {
           size="sm"
           onClick={() => setLocation('/')}
           className="p-2 hover:bg-white rounded-lg"
+          aria-label="Back to home"
           data-testid="button-back"
         >
           <ArrowLeft className="w-5 h-5 text-brand-grayDark" />
@@ -231,6 +232,7 @@ export default function ChildChoresPage({ childId }: ChildChoresPageProps) {
                       variant="ghost"
                       size="sm"
                       className={`p-2 ${isFavorite ? 'text-brand-yellow hover:text-brand-yellow/80' : 'text-brand-grayDark/40 hover:text-brand-yellow'} hover:bg-brand-yellow/10`}
+                      aria-label={isFavorite ? `Remove ${chore.title} from favorites` : `Add ${chore.title} to favorites`}
                       data-testid={`button-toggle-favorite-${chore.id}`}
                     >
                       <Star className={`w-4 h-4 ${isFavorite ? 'fill-current' : ''}`} />
@@ -240,6 +242,7 @@ export default function ChildChoresPage({ childId }: ChildChoresPageProps) {
                     variant="outline"
                     size="sm"
                     className="p-2 hover:bg-brand-grayLight"
+                    aria-label={`Edit ${chore.title}`}
                     data-testid={`button-edit-chore-${chore.id}`}
                   >
                     <Edit className="w-4 h-4" />
@@ -249,6 +252,7 @@ export default function ChildChoresPage({ childId }: ChildChoresPageProps) {
                     variant="outline"
                     size="sm"
                     className="p-2 hover:bg-red-50 hover:border-red-300 hover:text-red-600"
+                    aria-label={`Delete ${chore.title}`}
                     data-testid={`button-delete-chore-${chore.id}`}
                   >
                     <Trash2 className="w-4 h-4" />

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -75,7 +75,6 @@ export default function HomePage() {
       {/* Children Grid */}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {children?.map((child, index) => {
-          const completedChores = Math.floor(child.totalCents / 100); // Rough estimate
           const progressPercent = Math.min((child.totalCents / 1000) * 100, 100); // Progress to $10
 
           return (
@@ -99,14 +98,21 @@ export default function HomePage() {
                         <span className="text-sm text-brand-grayDark/60">earned</span>
                       </div>
                       <div className="flex items-center gap-1 mt-2">
-                        <div className="flex-1 bg-brand-grayLight rounded-full h-2">
-                          <div 
+                        <div
+                          className="flex-1 bg-brand-grayLight rounded-full h-2"
+                          role="progressbar"
+                          aria-valuenow={Math.round(progressPercent)}
+                          aria-valuemin={0}
+                          aria-valuemax={100}
+                          aria-label={`${child.name}'s progress toward $10 goal`}
+                        >
+                          <div
                             className="bg-gradient-to-r from-brand-teal to-brand-yellow h-2 rounded-full transition-all duration-300"
                             style={{ width: `${progressPercent}%` }}
                           />
                         </div>
                         <span className="text-xs text-brand-grayDark/60" data-testid={`text-child-progress-${child.id}`}>
-                          {completedChores} done
+                          toward $10 goal
                         </span>
                       </div>
                     </div>
@@ -130,7 +136,7 @@ export default function HomePage() {
       {/* Quick Stats */}
       <Card className="shadow-soft">
         <CardContent className="p-6">
-          <h2 className="text-xl font-semibold text-brand-grayDark mb-4">This Week</h2>
+          <h2 className="text-xl font-semibold text-brand-grayDark mb-4">Overview</h2>
           <div className="grid grid-cols-3 gap-4">
             <div className="text-center">
               <div className="flex items-center justify-center w-12 h-12 bg-brand-teal/10 rounded-xl mx-auto mb-2">
@@ -157,7 +163,7 @@ export default function HomePage() {
               <div className="text-2xl font-bold text-brand-yellow" data-testid="text-payouts">
                 {totalPayouts}
               </div>
-              <div className="text-sm text-brand-grayDark/60">Payouts</div>
+              <div className="text-sm text-brand-grayDark/60">Payouts (7 days)</div>
             </div>
           </div>
         </CardContent>

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -187,6 +187,7 @@ export default function SettingsPage() {
                     variant="ghost"
                     onClick={() => handleDeleteChild(child.id, child.name)}
                     className="text-brand-coral/60 hover:text-brand-coral hover:bg-brand-coral/10"
+                    aria-label={`Delete ${child.name}`}
                     data-testid={`button-delete-child-${child.id}`}
                   >
                     <Trash2 className="w-4 h-4" />

--- a/client/src/pages/TotalsPage.tsx
+++ b/client/src/pages/TotalsPage.tsx
@@ -74,8 +74,7 @@ export default function TotalsPage() {
       <div className="space-y-4">
         {children?.map((child, index) => {
           const childPayouts = payouts?.filter(p => p.childId === child.id) || [];
-          const choreCount = Math.floor(child.totalCents / 100); // Rough estimate
-          
+
           return (
             <Card key={child.id} className="shadow-soft" data-testid={`card-child-total-${child.id}`}>
               <CardContent className="p-6">
@@ -91,7 +90,7 @@ export default function TotalsPage() {
                         {child.name}
                       </h3>
                       <p className="text-brand-grayDark/60 text-sm" data-testid={`text-child-chores-${child.id}`}>
-                        {choreCount} chores completed • {childPayouts.length} total payouts
+                        {childPayouts.length} total payouts
                       </p>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- Add aria-label to every icon-only interactive element: the back button, star/edit/delete buttons per chore row (ChildChoresPage.tsx), the delete-child button (SettingsPage.tsx), and every nav tab in App.tsx (the icon-only Settings button plus Home/Totals/Chores/History, whose text is hidden below `sm`).
- Retitle the HomePage stats card from "This Week" to "Overview" since Active Kids and Total Earned are all-time, not weekly; relabel the Payouts stat "Payouts (7 days)" to state what it actually measures.
- State the per-child progress bar's $10 goal in visible text and give the bar `role="progressbar"` with `aria-valuenow`/`aria-valuemin`/`aria-valuemax`.
- Remove the fabricated completion counts derived from `Math.floor(totalCents / 100)` on HomePage ("N done") and TotalsPage ("N chores completed"), keeping the real "N total payouts" figure.

Closes #73
Closes #74
Closes #75

## Test plan
- [x] `pnpm install`
- [x] `pnpm run check` (tsc, no errors)
- [x] `pnpm run build` (vite + esbuild, succeeds)
- [ ] Manual smoke test in a browser: nav labels announce correctly, chore row buttons announce with chore names, stats card reads correctly, progress bar caption shows the $10 goal