### PR TITLE
fix(server): validate, rate-limit and sanitise the bug-report endpoint; security headers; dev/prod split

### DIFF
--- a/client/src/components/BugReport.tsx
+++ b/client/src/components/BugReport.tsx
@@ -19,6 +19,7 @@ import { Label } from '@/components/ui/label';
 import { Camera, Send, Loader2, X } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import html2canvas from 'html2canvas';
+import { bugReportCategories, type BugReportPayload } from '@shared/schema';
 
 interface BugReportProps {
   open: boolean;
@@ -26,21 +27,13 @@ interface BugReportProps {
 }
 
 type IssueType = 'bug' | 'feature';
+type BugCategory = (typeof bugReportCategories)[number];
 
-const CATEGORIES = [
-  'User Interface',
-  'Chores Management',
-  'Child Management',
-  'Rewards/Payouts',
-  'Settings',
-  'PWA/Offline',
-  'Performance',
-  'Other',
-];
+const CATEGORIES = bugReportCategories;
 
 export default function BugReport({ open, onOpenChange }: BugReportProps) {
   const [issueType, setIssueType] = useState<IssueType>('bug');
-  const [category, setCategory] = useState('');
+  const [category, setCategory] = useState<BugCategory | ''>('');
   const [description, setDescription] = useState('');
   const [stepsToReproduce, setStepsToReproduce] = useState('');
   const [expectedBehavior, setExpectedBehavior] = useState('');
@@ -118,7 +111,7 @@ export default function BugReport({ open, onOpenChange }: BugReportProps) {
 
     setIsSubmitting(true);
     try {
-      const payload = {
+      const payload: BugReportPayload = {
         issueType,
         category,
         description,
@@ -201,7 +194,7 @@ export default function BugReport({ open, onOpenChange }: BugReportProps) {
           {/* Category */}
           <div className="space-y-2">
             <Label>Category *</Label>
-            <Select value={category} onValueChange={setCategory}>
+            <Select value={category} onValueChange={(value) => setCategory(value as BugCategory)}>
               <SelectTrigger>
                 <SelectValue placeholder="Select a category" />
               </SelectTrigger>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "cross-env NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --external:./vite --bundle --format=esm --outdir=dist",
     "start": "cross-env NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"
@@ -53,6 +53,7 @@
     "drizzle-zod": "^0.8.3",
     "embla-carousel-react": "^8.6.0",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.6.2",
     "express-session": "^1.18.2",
     "framer-motion": "^12.23.24",
     "html2canvas": "^1.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.1.0
+      express-rate-limit:
+        specifier: ^8.6.2
+        version: 8.6.2(express@5.1.0)
       express-session:
         specifier: ^1.18.2
         version: 1.18.2
@@ -399,11 +402,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -2127,6 +2130,12 @@ packages:
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
+  express-rate-limit@8.6.2:
+    resolution: {integrity: sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express-session@1.18.2:
     resolution: {integrity: sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==}
     engines: {node: '>= 0.8.0'}
@@ -2268,6 +2277,10 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  ip-address@10.5.0:
+    resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
+    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -4883,6 +4896,14 @@ snapshots:
 
   eventemitter3@5.0.1: {}
 
+  express-rate-limit@8.6.2(express@5.1.0):
+    dependencies:
+      debug: 4.4.3
+      express: 5.1.0
+      ip-address: 10.5.0
+    transitivePeerDependencies:
+      - supports-color
+
   express-session@1.18.2:
     dependencies:
       cookie: 0.7.2
@@ -5056,6 +5077,8 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
 
   internmap@2.0.3: {}
+
+  ip-address@10.5.0: {}
 
   ipaddr.js@1.9.1: {}
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,10 +1,54 @@
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
-import { setupVite, serveStatic, log } from "./vite";
+import { log, serveStatic } from "./static";
+
+// Content-Security-Policy applied to everything except /api responses (which
+// are JSON, not documents a browser renders). 'unsafe-inline' on style-src
+// is required by Radix UI and other inline React styles.
+const CONTENT_SECURITY_POLICY = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "font-src https://fonts.gstatic.com",
+  "img-src 'self' data:",
+  "connect-src 'self'",
+  "manifest-src 'self'",
+  "worker-src 'self'",
+].join('; ');
+
+// Fail loud, not silent: a missing GITHUB_TOKEN otherwise only surfaces the
+// first time someone submits a bug report, as a bare 503, well after the
+// container has passed its healthcheck and been deployed.
+function checkRequiredEnv() {
+  if (!process.env.GITHUB_TOKEN) {
+    log('='.repeat(72));
+    log('WARNING: GITHUB_TOKEN is not set.');
+    log('Bug/feature reporting (POST /api/issues/create) is DISABLED and');
+    log('will respond 503 to every submission until this is fixed.');
+    log('Set GITHUB_TOKEN in the environment and redeploy.');
+    log('='.repeat(72));
+  }
+}
 
 const app = express();
-app.use(express.json());
+
+// The app runs behind Caddy and Cloudflare. Trust the first proxy hop so
+// req.ip (and therefore the rate limiter's key) reflects the real client
+// address instead of the reverse proxy's.
+app.set('trust proxy', 1);
+
+// Don't advertise the framework.
+app.disable('x-powered-by');
+
+app.use(express.json({ limit: '10mb' })); // screenshots need more than the 100kb default
 app.use(express.urlencoded({ extended: false }));
+
+app.use((req, res, next) => {
+  if (!req.path.startsWith('/api')) {
+    res.setHeader('Content-Security-Policy', CONTENT_SECURITY_POLICY);
+  }
+  next();
+});
 
 app.use((req, res, next) => {
   const start = Date.now();
@@ -37,20 +81,29 @@ app.use((req, res, next) => {
 });
 
 (async () => {
+  checkRequiredEnv();
+
   const server = await registerRoutes(app);
 
-  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
+  app.use((err: any, req: Request, res: Response, _next: NextFunction) => {
     const status = err.status || err.statusCode || 500;
-    const message = err.message || "Internal Server Error";
 
-    res.status(status).json({ message });
-    throw err;
+    // Log the full error server-side; never forward internal error detail
+    // (stack traces, upstream API URLs, rate-limit info) to the client.
+    console.error(`[error] ${req.method} ${req.path} -> ${status}`, err);
+
+    res.status(status).json({ message: "Internal Server Error" });
   });
 
   // importantly only setup vite in development and after
   // setting up all the other routes so the catch-all route
   // doesn't interfere with the other routes
+  //
+  // The vite dev middleware is loaded via a dynamic import gated on this
+  // branch, and "./vite" is built as an external module (see package.json's
+  // build script), so the production bundle never pulls in the vite package.
   if (app.get("env") === "development") {
+    const { setupVite } = await import("./vite");
     await setupVite(app, server);
   } else {
     serveStatic(app);

--- a/server/routes/issues.ts
+++ b/server/routes/issues.ts
@@ -1,5 +1,7 @@
 import { Router, type Request, type Response } from 'express';
 import { Octokit } from '@octokit/rest';
+import rateLimit from 'express-rate-limit';
+import { bugReportSchema } from '../../shared/schema';
 
 const router = Router();
 
@@ -8,52 +10,97 @@ const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const GITHUB_REPO_OWNER = process.env.GITHUB_REPO_OWNER || 'rodlunt';
 const GITHUB_REPO_NAME = process.env.GITHUB_REPO_NAME || 'choresandrewardsV2';
 
-interface BugReportPayload {
-  issueType: 'bug' | 'feature';
-  category: string;
-  description: string;
-  stepsToReproduce?: string;
-  expectedBehavior?: string;
-  actualBehavior?: string;
-  screenshot?: string | null;
-  technicalInfo: {
-    timestamp: string;
-    userAgent: string;
-    url: string;
-    resolution: string;
-    appVersion: string;
-    buildNumber: string;
-  };
+const MAX_SCREENSHOT_BYTES = 5 * 1024 * 1024; // 5 MB decoded
+
+// Detect the actual image format from its magic bytes rather than trusting
+// the data URL's declared mime type. Only PNG, JPEG and WebP are accepted.
+function detectImageType(buffer: Buffer): 'png' | 'jpeg' | 'webp' | null {
+  if (
+    buffer.length >= 4 &&
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47
+  ) {
+    return 'png';
+  }
+
+  if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return 'jpeg';
+  }
+
+  if (
+    buffer.length >= 12 &&
+    buffer.toString('ascii', 0, 4) === 'RIFF' &&
+    buffer.toString('ascii', 8, 12) === 'WEBP'
+  ) {
+    return 'webp';
+  }
+
+  return null;
 }
 
+// A handful of reports per IP per hour is enough for genuine use and cheap
+// to spam past, but keeps the endpoint from being used to mint unlimited
+// GitHub issues and screenshot uploads.
+const createIssueLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  limit: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { message: 'Too many reports submitted. Please try again later.' },
+});
+
 // POST /api/issues/create
-router.post('/create', async (req: Request, res: Response) => {
-  try {
-    const {
-      issueType,
-      category,
-      description,
-      stepsToReproduce,
-      expectedBehavior,
-      actualBehavior,
-      screenshot,
-      technicalInfo,
-    } = req.body as BugReportPayload;
+router.post('/create', createIssueLimiter, async (req: Request, res: Response) => {
+  const parseResult = bugReportSchema.safeParse(req.body);
+  if (!parseResult.success) {
+    return res.status(400).json({
+      message: 'Invalid bug report payload.',
+    });
+  }
 
-    // Validate required fields
-    if (!issueType || !category || !description) {
+  const {
+    issueType,
+    category,
+    description,
+    stepsToReproduce,
+    expectedBehavior,
+    actualBehavior,
+    screenshot,
+    technicalInfo,
+  } = parseResult.data;
+
+  // Validate the screenshot content server-side: the client's declared mime
+  // type in the data URL prefix is not trustworthy on its own.
+  let screenshotBase64: string | null = null;
+  if (screenshot) {
+    const base64Data = screenshot.replace(/^data:image\/\w+;base64,/, '');
+    const decoded = Buffer.from(base64Data, 'base64');
+
+    if (decoded.length > MAX_SCREENSHOT_BYTES) {
       return res.status(400).json({
-        message: 'Missing required fields: issueType, category, description',
+        message: 'Screenshot is too large.',
       });
     }
 
-    if (!GITHUB_TOKEN) {
-      console.error('GITHUB_TOKEN not configured');
-      return res.status(500).json({
-        message: 'GitHub integration not configured. Please contact support.',
+    if (!detectImageType(decoded)) {
+      return res.status(400).json({
+        message: 'Screenshot does not look like a valid image.',
       });
     }
 
+    screenshotBase64 = base64Data;
+  }
+
+  if (!GITHUB_TOKEN) {
+    console.error('GITHUB_TOKEN not configured; refusing bug report submission');
+    return res.status(503).json({
+      message: 'Bug reporting is temporarily unavailable. Please contact support.',
+    });
+  }
+
+  try {
     // Initialize Octokit
     const octokit = new Octokit({
       auth: GITHUB_TOKEN,
@@ -110,13 +157,9 @@ router.post('/create', async (req: Request, res: Response) => {
     const issueNumber = issueResponse.data.number;
     console.log(`Created issue #${issueNumber}: ${title}`);
 
-    // Handle screenshot upload if provided
-    if (screenshot && screenshot.startsWith('data:image')) {
+    // Handle screenshot upload if provided (already content-validated above)
+    if (screenshotBase64) {
       try {
-        // Extract base64 data
-        const base64Data = screenshot.replace(/^data:image\/\w+;base64,/, '');
-        const buffer = Buffer.from(base64Data, 'base64');
-
         // Generate filename
         const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
         const filename = `bug-report-${issueNumber}-${timestamp}.png`;
@@ -152,7 +195,7 @@ router.post('/create', async (req: Request, res: Response) => {
           repo: GITHUB_REPO_NAME,
           path: filePath,
           message: `Add screenshot for issue #${issueNumber}`,
-          content: base64Data,
+          content: screenshotBase64,
           branch: screenshotBranch,
         });
 
@@ -178,7 +221,7 @@ router.post('/create', async (req: Request, res: Response) => {
       }
     }
 
-    res.json({
+    res.status(201).json({
       success: true,
       issueNumber,
       url: issueResponse.data.html_url,
@@ -187,7 +230,6 @@ router.post('/create', async (req: Request, res: Response) => {
     console.error('Error creating GitHub issue:', error);
     res.status(500).json({
       message: 'Failed to create issue. Please try again.',
-      error: error instanceof Error ? error.message : 'Unknown error',
     });
   }
 });

--- a/server/static.ts
+++ b/server/static.ts
@@ -1,0 +1,36 @@
+import express, { type Express } from "express";
+import fs from "fs";
+import path from "path";
+
+// Deliberately imports nothing from the "vite" package: this module is
+// loaded unconditionally (dev and production alike), while server/vite.ts
+// is loaded only in development via a dynamic import. Keeping this file
+// vite-free is what keeps vite out of the production bundle.
+
+export function log(message: string, source = "express") {
+  const formattedTime = new Date().toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: true,
+  });
+
+  console.log(`${formattedTime} [${source}] ${message}`);
+}
+
+export function serveStatic(app: Express) {
+  const distPath = path.resolve(import.meta.dirname, "public");
+
+  if (!fs.existsSync(distPath)) {
+    throw new Error(
+      `Could not find the build directory: ${distPath}, make sure to build the client first`,
+    );
+  }
+
+  app.use(express.static(distPath));
+
+  // fall through to index.html if the file doesn't exist
+  app.use((_req, res) => {
+    res.sendFile(path.resolve(distPath, "index.html"));
+  });
+}

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,4 +1,4 @@
-import express, { type Express } from "express";
+import { type Express } from "express";
 import fs from "fs";
 import path from "path";
 import { createServer as createViteServer, createLogger } from "vite";
@@ -6,18 +6,14 @@ import { type Server } from "http";
 import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";
 
+// Development-only: this module imports the "vite" package, so it must
+// never be imported from a code path that also runs in production. It is
+// loaded exclusively via a dynamic import from server/index.ts, gated on
+// NODE_ENV === "development", so esbuild's production bundle never pulls
+// vite in. Static-file serving and the shared `log` helper live in
+// server/static.ts, which both dev and prod use.
+
 const viteLogger = createLogger();
-
-export function log(message: string, source = "express") {
-  const formattedTime = new Date().toLocaleTimeString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: true,
-  });
-
-  console.log(`${formattedTime} [${source}] ${message}`);
-}
 
 export async function setupVite(app: Express, server: Server) {
   const serverOptions = {
@@ -64,22 +60,5 @@ export async function setupVite(app: Express, server: Server) {
       vite.ssrFixStacktrace(e as Error);
       next(e);
     }
-  });
-}
-
-export function serveStatic(app: Express) {
-  const distPath = path.resolve(import.meta.dirname, "public");
-
-  if (!fs.existsSync(distPath)) {
-    throw new Error(
-      `Could not find the build directory: ${distPath}, make sure to build the client first`,
-    );
-  }
-
-  app.use(express.static(distPath));
-
-  // fall through to index.html if the file doesn't exist
-  app.use((_req, res) => {
-    res.sendFile(path.resolve(distPath, "index.html"));
   });
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -71,3 +71,44 @@ export const appDataSchema = z.object({
 });
 
 export type AppData = z.infer<typeof appDataSchema>;
+
+// Bug report / feature request schema
+// Single source of truth for the payload shape shared by the client
+// (BugReport.tsx) and the server (routes/issues.ts), so a rename on either
+// side fails type-checking instead of breaking silently at runtime.
+export const bugReportCategories = [
+  'User Interface',
+  'Chores Management',
+  'Child Management',
+  'Rewards/Payouts',
+  'Settings',
+  'PWA/Offline',
+  'Performance',
+  'Other',
+] as const;
+
+const technicalInfoFieldSchema = z.string().max(500);
+
+export const bugReportSchema = z.object({
+  issueType: z.enum(['bug', 'feature']),
+  category: z.enum(bugReportCategories),
+  description: z.string().min(1, 'Description is required').max(5000),
+  stepsToReproduce: z.string().max(5000).optional(),
+  expectedBehavior: z.string().max(5000).optional(),
+  actualBehavior: z.string().max(5000).optional(),
+  screenshot: z
+    .string()
+    .startsWith('data:image/', 'Screenshot must be a data:image/* URL')
+    .nullable()
+    .optional(),
+  technicalInfo: z.object({
+    timestamp: technicalInfoFieldSchema,
+    userAgent: technicalInfoFieldSchema,
+    url: technicalInfoFieldSchema,
+    resolution: technicalInfoFieldSchema,
+    appVersion: technicalInfoFieldSchema,
+    buildNumber: technicalInfoFieldSchema,
+  }),
+});
+
+export type BugReportPayload = z.infer<typeof bugReportSchema>;


### PR DESCRIPTION
## Summary

Closes #44
Closes #54
Closes #55
Closes #57
Closes #60
Closes #65
Closes #66
Closes #69

- **#65 + #54**: Added `bugReportSchema` (and `bugReportCategories`, `BugReportPayload`) to `shared/schema.ts` as the single source of truth for the bug-report payload shape. `server/routes/issues.ts` now validates every submission with `bugReportSchema.safeParse(req.body)` and rejects invalid payloads with a generic 400 (no Zod internals leaked). `BugReport.tsx` imports the shared type and category list instead of duplicating them, so a rename on either side now fails type-checking instead of breaking silently at runtime.
- **#57**: Added `express-rate-limit`, capping `POST /api/issues/create` at 5 requests/hour/IP (standard headers, generic message). Screenshots are content-validated server-side: decoded and checked against PNG/JPEG/WebP magic bytes, and rejected over 5 MB decoded. `app.set('trust proxy', 1)` is set so the limiter keys on the real client IP behind Caddy/Cloudflare.
- Raised the JSON body limit to 10mb in `server/index.ts` (the previous 100kb default rejected any real screenshot).
- **#60**: The issue-creation route and the global error handler now log the full error server-side and return only a fixed generic message; `error.message` is never sent to the client.
- **#66**: Issue creation now returns 201 on success; a missing `GITHUB_TOKEN` now returns 503 instead of 500, so monitoring can distinguish "deployed without config" from "GitHub call failed".
- **#69**: `server/index.ts` checks `GITHUB_TOKEN` at startup and logs a prominent multi-line warning if it's missing, without exiting — the rest of the app still serves.
- **#44**: Removed the `throw err` after the response was already sent in the global error middleware; it now logs the error with request method/path/status instead.
- **#55**: `app.disable('x-powered-by')`, plus a Content-Security-Policy header on all non-`/api` responses (`default-src 'self'`, `'unsafe-inline'` on style-src for Radix/inline React styles, Google Fonts allowed for style/font-src, etc).
- Dev/prod split: moved `serveStatic`/`log` out of `server/vite.ts` into a new vite-free `server/static.ts`. `server/vite.ts` (and the `vite` package it imports) is now loaded only via a dynamic `await import("./vite")` inside the development branch, and the build script marks `./vite` external to esbuild, so the production bundle never pulls in vite. Verified: `grep -c 'from "vite"' dist/index.js` and `grep -n 'require("vite")' dist/index.js` are both empty in the production bundle, and `createViteServer`/`viteConfig` do not appear in it either.

## Test plan

- [x] `pnpm install`
- [x] `pnpm run check` (tsc, clean)
- [x] `pnpm run build` (vite build + esbuild bundle)
- [x] `ls dist` — `index.js` and `public/` present
- [x] `grep -c 'from "vite"' dist/index.js` -> 0
- [x] `grep -n 'require("vite")' dist/index.js` -> no matches
- [x] Ran `dist/index.js` with `NODE_ENV=production` and no `GITHUB_TOKEN`: server starts, logs the startup warning, still serves; response headers show CSP present and no `X-Powered-By`
- [x] `POST /api/issues/create` with a well-formed payload and no `GITHUB_TOKEN` -> 503
- [x] `POST /api/issues/create` with an invalid `category` -> 400 with a generic message
- [x] Ran `tsx server/index.ts` in `NODE_ENV=development`: dynamic `import("./vite")` resolves and the dev server boots cleanly