### PR TITLE
ci: PR-triggered gates, split audit job, environment-scoped deploy

### DIFF
--- a/.github/workflows/validate-and-deploy.yml
+++ b/.github/workflows/validate-and-deploy.yml
@@ -4,12 +4,43 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  audit:
+    name: Security audit
+    runs-on: ubuntu-latest
+    concurrency:
+      group: audit-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Own job, not a step inside validate: an audit failure must not stop
+      # type-check and build from reporting their own status.
+      - name: Security audit
+        run: pnpm audit --audit-level=high
+
   validate:
     name: Run Pre-Deployment Checks
     runs-on: ubuntu-latest
@@ -32,9 +63,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Security audit
-        run: pnpm audit --audit-level=high
 
       - name: TypeScript type check
         run: pnpm run check
@@ -88,8 +116,12 @@ jobs:
 
   deploy:
     name: Deploy to Server
-    needs: validate
+    needs: [validate, audit]
+    # Pull requests run the gates only; deployment happens on push to main
+    # (and manual dispatch), never from a PR ref.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    environment: production
     concurrency:
       group: production-deploy
       cancel-in-progress: false


### PR DESCRIPTION
Wires the CI shape needed to make issues #47 and #52 enforceable:

- pull_request trigger on main, so the gates run on PRs and can be required status checks (the workflow previously only ran on push, meaning a required check would never report on a PR).
- Security audit becomes its own job: a failing advisory can no longer mask whether type-check and build pass.
- Deploy needs both validate and audit, never runs on PR events, and declares environment: production for secret scoping and deploy history.

Branch protection and the environment itself are applied via the API after this merges (settings, not files). Contributes to #47 and #52; those close when the settings are live.