### PR TITLE
fix(docker): multi-stage production image, digest-pinned base

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,6 +24,11 @@ deployment-instructions.md
 .vscode
 .idea
 
+# Claude Code / engineering-audit tooling: never needed in the image
+.claude
+audit-output
+docs
+
 # OS
 .DS_Store
 Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,48 @@
 # Dockerfile for Chores & Rewards PWA
-FROM node:22-alpine
+#
+# Multi-stage build: the build stage compiles the client (vite) and bundles
+# the server (esbuild, --packages=external --external:./vite) into
+# dist/index.js + dist/public/. The runtime stage installs only production
+# node_modules and runs the built bundle directly with node, so vite, esbuild,
+# tsx and the rest of devDependencies never ship in the deployed image.
+#
+# Base image pinned by digest (see #59): node:22-alpine, resolved 2026-08-18
+# via the registry API (docker-content-digest header on a HEAD-equivalent
+# manifest request for the linux multi-arch index).
+FROM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS build
 
-# Install curl for health checks
-RUN apk add --no-cache curl
-
-# Set working directory
 WORKDIR /app
 
-# Copy package files
+# Copy package files first so this layer caches independently of source changes.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
-# Install ALL dependencies (needed for build)
+# Install ALL dependencies (build tooling - vite, esbuild - is only needed here).
 RUN corepack enable pnpm && pnpm install --frozen-lockfile
 
-# Copy application code
+# Copy application source and build both the client bundle and the server bundle.
 COPY . .
-
-# Build the client application
 RUN pnpm run build
 
-# Copy built files to where server expects them
-RUN cp -r dist/public server/public
+FROM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS runtime
 
-# Don't clean up dev dependencies - we need tsx for production
-# RUN pnpm prune --prod
+# curl is needed for the healthcheck below; nothing else from apk is required
+# at runtime.
+RUN apk add --no-cache curl
 
-# Expose port
+WORKDIR /app
+
+# Install production dependencies only - no vite, esbuild, tsx or other
+# devDependencies in the final image.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN corepack enable pnpm && pnpm install --prod --frozen-lockfile
+
+# Copy the built server bundle and client assets from the build stage.
+# server/static.ts resolves the client directory relative to dist/index.js,
+# so dist/public must sit alongside dist/index.js as-is.
+COPY --from=build /app/dist ./dist
+
 EXPOSE 5000
 
-# Set environment variables
 ENV NODE_ENV=production
 ENV PORT=5000
 
@@ -36,5 +50,5 @@ ENV PORT=5000
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD curl -f http://localhost:5000 || exit 1
 
-# Start the application directly with tsx (avoids bundling issues)
-CMD ["pnpm", "exec", "tsx", "server/index.ts"]
+# Run the built bundle directly - no tsx, no dev tooling in the container.
+CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary
- Rewrite the Dockerfile as a multi-stage build: a `build` stage installs full dependencies and runs `pnpm run build`; the `runtime` stage installs production node_modules only (`pnpm install --prod --frozen-lockfile`) and copies `dist/` from the build stage. The container now starts with `node dist/index.js` instead of `pnpm exec tsx server/index.ts`, so vite, esbuild, tsx and the rest of devDependencies never ship in the deployed image.
- Pin both stages' base image by digest: `node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32`, resolved from the registry API rather than trusting the mutable `22-alpine` tag.
- Trim `.dockerignore` to exclude `.claude`, `audit-output` and `docs` in addition to the existing `node_modules`, `dist`, `.git` and `*.md` exclusions, keeping the build context lean.

Closes #58
Closes #59

## Digest evidence
```
curl -sI \
  -H "Authorization: Bearer $TOKEN" \
  -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
  -H "Accept: application/vnd.oci.image.index.v1+json" \
  "https://registry-1.docker.io/v2/library/node/manifests/22-alpine"

HTTP/2 200
content-type: application/vnd.oci.image.index.v1+json
docker-content-digest: sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32
etag: "sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32"
```
Token obtained anonymously from `https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/node:pull`. Resolved 2026-08-18 against the `node:22-alpine` tag (OCI image index, i.e. the multi-arch manifest list).

## Caveat: image not actually built
No Docker daemon is available in this environment, so the multi-stage build itself was never run through `docker build`. Instead the runtime recipe was simulated directly on the host:

1. `pnpm install --frozen-lockfile && pnpm run build` in the worktree - succeeded, produced `dist/index.js` (11.6kb) and `dist/public/`.
2. Copied `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml` and `dist/` into a scratch directory and ran `pnpm install --prod --frozen-lockfile` there - completed, `devDependencies: skipped`.
3. Started the app from that directory with `NODE_ENV=production PORT=5599 node dist/index.js` - came up clean, logged `serving on port 5599`.
4. `curl -s -o /dev/null -w '%{http_code}' http://localhost:5599/` -> `200`.
5. `curl -s http://localhost:5599/api/issues/create -X POST -H 'Content-Type: application/json' -d '{}'` -> `{"message":"Invalid bug report payload."}` with HTTP `400`.
6. Killed the process and deleted the scratch directory.

This proves the *runtime contract* (prod-only install, `node dist/index.js`, static file serving out of `dist/public`, request handling) works exactly as the new Dockerfile's runtime stage expects. It does **not** prove the actual `docker build` succeeds inside the alpine container (apk install, corepack enable inside that base image, layer copy semantics). **Watch the first deploy closely** - if the build stage fails inside the real image, it will most likely be corepack/pnpm activation on a fresh alpine base or an apk package resolution issue, neither of which this host-side simulation can catch.

Also noticed in passing (not fixed here, out of scope for this PR): `pnpm why esbuild` shows `esbuild` and `tsx` land in the runtime `node_modules` anyway, as transitive dependencies of `tailwindcss-animate` (a `dependencies` entry, not `devDependencies`) via `tailwindcss` -> `postcss-load-config` -> `tsx`. They aren't started or used at runtime, but they do increase the image's dependency surface beyond what `pnpm install --prod` alone suggests. Worth a look separately if the audit gate cares about exact package presence, not just what's invoked.

## Test plan
- [x] `pnpm run build` succeeds and produces `dist/index.js` + `dist/public/`
- [x] `pnpm install --prod --frozen-lockfile` in isolation skips devDependencies
- [x] `node dist/index.js` serves `/` with 200
- [x] `node dist/index.js` validates `/api/issues/create` and returns 400 on an empty payload
- [ ] `docker build` and container boot on first real deploy (not verifiable here, no daemon)