### PR TITLE
fix(server): rate limiter keys on the real client IP, not the Cloudflare edge

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -32,10 +32,17 @@ function checkRequiredEnv() {
 
 const app = express();
 
-// The app runs behind Caddy and Cloudflare. Trust the first proxy hop so
-// req.ip (and therefore the rate limiter's key) reflects the real client
-// address instead of the reverse proxy's.
-app.set('trust proxy', 1);
+// The app sits behind exactly two proxies: Cloudflare (which appends the
+// real client IP to X-Forwarded-For) then Caddy (which appends the CF edge
+// address). Trusting two hops makes req.ip, and therefore the rate
+// limiter's key, resolve to the client Cloudflare recorded, even when a
+// caller sends a forged X-Forwarded-For through Cloudflare. With only one
+// hop trusted, req.ip was the CF edge and the limiter pooled unrelated
+// users per edge. Known residual: a request that reaches Caddy directly,
+// bypassing Cloudflare, can spoof req.ip with a forged header; the only
+// thing keyed off req.ip is the rate limiter, so the exposure is limit
+// evasion, nothing else.
+app.set('trust proxy', 2);
 
 // Don't advertise the framework.
 app.disable('x-powered-by');


### PR DESCRIPTION
Follow-up to the nuance recorded on #57: with trust proxy 1 behind Cloudflare and Caddy, req.ip was the CF edge, so the 5/hour limit pooled unrelated users per edge and gave attackers a fresh allowance per edge. Trusting exactly two hops resolves req.ip to the client Cloudflare recorded, which also stands up to forged X-Forwarded-For sent through Cloudflare. Residual risk (direct-to-origin spoofing) is documented in the code comment and only affects the limiter.