### PR TITLE
fix(server): rate limiter keys on CF-Connecting-IP; trust proxy back to 1

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -32,17 +32,15 @@ function checkRequiredEnv() {
 
 const app = express();
 
-// The app sits behind exactly two proxies: Cloudflare (which appends the
-// real client IP to X-Forwarded-For) then Caddy (which appends the CF edge
-// address). Trusting two hops makes req.ip, and therefore the rate
-// limiter's key, resolve to the client Cloudflare recorded, even when a
-// caller sends a forged X-Forwarded-For through Cloudflare. With only one
-// hop trusted, req.ip was the CF edge and the limiter pooled unrelated
-// users per edge. Known residual: a request that reaches Caddy directly,
-// bypassing Cloudflare, can spoof req.ip with a forged header; the only
-// thing keyed off req.ip is the rate limiter, so the exposure is limit
-// evasion, nothing else.
-app.set('trust proxy', 2);
+// The app sits behind Cloudflare then Caddy. Caddy has no trusted_proxies
+// configured, so (since Caddy 2.5) it strips the incoming X-Forwarded-For
+// and forwards only its own peer address, the CF edge. Trusting one hop
+// therefore resolves req.ip to the CF edge, which is the best XFF can do
+// here; do NOT raise this to 2 expecting the real client, and do not trust
+// hop-counted XFF for anything security relevant. The rate limiter derives
+// the real visitor address from CF-Connecting-IP instead (see
+// routes/issues.ts).
+app.set('trust proxy', 1);
 
 // Don't advertise the framework.
 app.disable('x-powered-by');

--- a/server/routes/issues.ts
+++ b/server/routes/issues.ts
@@ -1,6 +1,6 @@
 import { Router, type Request, type Response } from 'express';
 import { Octokit } from '@octokit/rest';
-import rateLimit from 'express-rate-limit';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import { bugReportSchema } from '../../shared/schema';
 
 const router = Router();
@@ -43,12 +43,30 @@ function detectImageType(buffer: Buffer): 'png' | 'jpeg' | 'webp' | null {
 // A handful of reports per IP per hour is enough for genuine use and cheap
 // to spam past, but keeps the endpoint from being used to mint unlimited
 // GitHub issues and screenshot uploads.
+//
+// Keying: Cloudflare overwrites CF-Connecting-IP on every proxied request
+// with the real visitor address, so through CF it is not attacker
+// controllable, and Caddy passes it through untouched. X-Forwarded-For is
+// useless here: Caddy has no trusted_proxies configured, so (since Caddy
+// 2.5) it strips the incoming XFF and forwards only its own peer, which is
+// the CF edge, and keying on req.ip would pool unrelated users per edge.
+// The req.ip fallback covers direct LAN access, where the CF header is
+// absent. Residual: a request that reaches the origin directly, bypassing
+// Cloudflare, can forge CF-Connecting-IP; the only thing keyed off it is
+// this limiter, so the exposure is limit evasion, nothing else.
 const createIssueLimiter = rateLimit({
   windowMs: 60 * 60 * 1000,
   limit: 5,
   standardHeaders: true,
   legacyHeaders: false,
   message: { message: 'Too many reports submitted. Please try again later.' },
+  keyGenerator: (req) => {
+    const cfIp = req.headers['cf-connecting-ip'];
+    if (typeof cfIp === 'string' && cfIp.length > 0) {
+      return ipKeyGenerator(cfIp);
+    }
+    return ipKeyGenerator(req.ip ?? '');
+  },
 });
 
 // POST /api/issues/create


### PR DESCRIPTION
Supersedes the PR #84 approach, which a push-time security review correctly faulted: with no trusted_proxies in Caddy, Caddy (2.5+) strips incoming X-Forwarded-For and forwards only its own peer, so hop-counted trust can never recover the real client here, and had XFF passed through, hop counting would have been forgeable.

- Rate limiter now keys on CF-Connecting-IP, which Cloudflare overwrites on every proxied request (not attacker-controllable through CF; passed through untouched by Caddy), IPv6-normalised via express-rate-limit's ipKeyGenerator, with req.ip fallback for direct LAN access where the header is absent.
- trust proxy back to 1, with a comment warning against raising it.
- Residual, documented in code: direct-to-origin requests bypassing Cloudflare can forge the header; only the limiter keys off it, so the exposure is limit evasion.