### PR TITLE
feat(issues): logging and alerting for the bug-report endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,20 @@ GITHUB_REPO_NAME=choresandrewardsV2
 # Optional: App Version Information (displayed in bug reports)
 VITE_APP_VERSION=1.0.0
 VITE_BUILD_NUMBER=dev
+
+# Optional: Error reporting for the bug-report endpoint (issue #61)
+# DSN from a GlitchTip (Sentry-compatible) project. Reports GitHub API
+# failures and unexpected exceptions. Absent = error reporting disabled;
+# faults still get logged to the console, just not shipped off-box.
+SENTRY_DSN=
+
+# Optional: ntfy alerting for the bug-report endpoint (issue #61)
+# Topic URL to POST alerts to, e.g. https://ntfy.example.com/candr-alerts
+# Absent = ntfy alerting disabled; alerts still get logged to the console.
+NTFY_URL=
+# Bearer token for the ntfy topic, if it requires auth.
+NTFY_TOKEN=
+# Accepted-submission count that triggers one burst alert per window.
+NTFY_BURST_THRESHOLD=10
+# Rolling window (minutes) the burst threshold is measured over.
+NTFY_BURST_WINDOW_MINUTES=60

--- a/docs/security/alerting-setup.md
+++ b/docs/security/alerting-setup.md
@@ -1,0 +1,69 @@
+# Bug-report endpoint: logging and alerting setup
+
+Recorded 2026-08-19 (issue #61). Operator notes for the logging and alerting added to
+`POST /api/issues/create`. See `docs/security/threat-model-issues-endpoint.md` for the
+threat model this sits inside.
+
+## What's always on
+
+Every submission (accepted, rejected, or failed) emits one structured JSON log line to the
+container's stdout/stderr, whether or not any of the config below is set. Fields: `timestamp`,
+`event`, `outcome`, `status`, plus a reason category where relevant. Report content, screenshot
+bytes, and tokens are never logged.
+
+Events: `submission-accepted`, `rejected-validation`, `rejected-rate-limit`,
+`rejected-screenshot`, `token-missing`, `github-api-failure`, `screenshot-upload-failed`,
+`alerting-delivery-failed`.
+
+`docker logs chores-rewards-app` shows these; grep for `"event":"github-api-failure"` etc.
+
+## What's optional (off by default)
+
+Two independent alerting channels, both gated purely on environment variables. Neither is
+required for the app or the bug-report feature to work: absent config means the feature is
+silently disabled, with a one-line notice logged once at startup so a forgotten env var is
+visible in `docker logs` rather than only mattering the day it would have paged someone.
+
+### GlitchTip (error reporting)
+
+Set `SENTRY_DSN` to a GlitchTip project's DSN (Settings -> Client Keys (DSN) in the GlitchTip
+UI) to report two genuine-fault categories: `github-api-failure` and any unhandled exception
+that reaches the app's top-level error handler. Delivery is a small dependency-free fetch()
+call against GlitchTip's Sentry-compatible store endpoint, not the `@sentry/node` SDK (see the
+PR that introduced this for the reasoning). Delivery is best-effort: if GlitchTip is
+unreachable the request being served is unaffected, and the failure is logged as
+`alerting-delivery-failed`.
+
+### ntfy (paging alerts)
+
+Set `NTFY_URL` (and `NTFY_TOKEN` if the topic requires auth) to enable two alerts:
+
+- **Volume burst**: fires once when accepted submissions exceed `NTFY_BURST_THRESHOLD`
+  (default 10) within a rolling `NTFY_BURST_WINDOW_MINUTES` window (default 60), then re-arms
+  only once the window has quieted back under the threshold. This is a separate signal from
+  the per-IP rate limit (5/hour) documented in `bug-report-access-policy.md`: it catches abuse
+  spread across many clients, each individually under that limit.
+- **GitHub API failure**: fires on the first `github-api-failure`, throttled to at most one per
+  hour, because a broken GitHub integration otherwise loses reports silently.
+
+Both are sent with `Priority: high` and an ASCII-only title. Delivery is best-effort: a failed
+ntfy send can't page anyone by definition, so it's logged loudly instead
+(`alerting-delivery-failed`) as the only remaining trail.
+
+## Environment variables
+
+| Variable | Default | Effect when unset |
+|---|---|---|
+| `SENTRY_DSN` | (none) | Error reporting to GlitchTip disabled |
+| `NTFY_URL` | (none) | ntfy alerting disabled |
+| `NTFY_TOKEN` | (none) | Alerts sent without an `Authorization` header |
+| `NTFY_BURST_THRESHOLD` | `10` | n/a (only used when `NTFY_URL` is set) |
+| `NTFY_BURST_WINDOW_MINUTES` | `60` | n/a (only used when `NTFY_URL` is set) |
+
+## Known gaps
+
+- Burst tracking and the GitHub-failure throttle are in-memory per container: both reset on
+  redeploy. Acceptable at this traffic level, same trade-off as the rate limiter itself.
+- Nothing watches these alerting paths themselves; a GlitchTip or ntfy outage is only visible
+  as `alerting-delivery-failed` log lines, which nobody is paged on. Acceptable for a hobby
+  project's secondary alerting channel; would need its own watchdog to close fully.

--- a/docs/security/threat-model-issues-endpoint.md
+++ b/docs/security/threat-model-issues-endpoint.md
@@ -31,6 +31,8 @@ using a fine-grained PAT from the server `.env`.
 | Oversized bodies | 10 MB JSON body limit |
 | Backend fingerprinting via errors | Generic error messages only; details go to server logs; `x-powered-by` disabled |
 | Token theft via server compromise | Token scope limits blast radius to the intake repo; rotation at most 90 days out |
+| Abuse spread across many clients (under the per-IP limit) | Structured logs for every rejection/failure category, plus an ntfy burst alert when accepted submissions exceed a threshold in a rolling window (see `docs/security/alerting-setup.md`) |
+| Silent GitHub integration failure (reports lost, nobody notices) | `github-api-failure` events are logged, reported to GlitchTip, and alert via ntfy (throttled to 1/hour) |
 | Publishing family data | Intake repo is private; the form discloses that reports are private; public issues are written by hand, sanitised (see the access policy) |
 
 ## Accepted residual risks
@@ -42,5 +44,7 @@ using a fine-grained PAT from the server `.env`.
   this traffic level.
 - No CAPTCHA or auth on submission: deliberate, to keep the report path frictionless for
   family and visitors. The rate limit and private intake bound the damage.
-- Abuse is currently detected by noticing, not by alerting; issue #61 tracks wiring
-  endpoint failures and volume bursts into GlitchTip and ntfy.
+- Alerting delivery (GlitchTip, ntfy) is itself best-effort: if either is unreachable the
+  request path is unaffected and the failure is only visible in container logs. Both default
+  off, so a deploy that never sets `SENTRY_DSN` / `NTFY_URL` gets no alerting at all, only the
+  structured logs. See `docs/security/alerting-setup.md` (issue #61).

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,8 @@
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { log, serveStatic } from "./static";
+import { errorReportingEnabled, reportFault } from "./lib/glitchtip";
+import { ntfyEnabled, BURST_THRESHOLD, BURST_WINDOW_MINUTES } from "./lib/ntfy";
 
 // Content-Security-Policy applied to everything except /api responses (which
 // are JSON, not documents a browser renders). 'unsafe-inline' on style-src
@@ -28,6 +30,24 @@ function checkRequiredEnv() {
     log('Set GITHUB_TOKEN in the environment and redeploy.');
     log('='.repeat(72));
   }
+}
+
+// Alerting is entirely optional and env-gated (issue #61): a deploy with
+// none of it configured must work unchanged. Log the state once at startup
+// so a misconfigured or forgotten env var is visible in `docker logs`
+// straight away, rather than only being noticed the first time it matters.
+function logAlertingStatus() {
+  log(
+    errorReportingEnabled
+      ? 'Error reporting is ENABLED (SENTRY_DSN set): GitHub API failures and unexpected exceptions will be sent to GlitchTip.'
+      : 'Error reporting is DISABLED (SENTRY_DSN not set). Faults will only appear in these logs.',
+  );
+
+  log(
+    ntfyEnabled
+      ? `ntfy alerting is ENABLED (NTFY_URL set): a burst alert fires above ${BURST_THRESHOLD} accepted reports per ${BURST_WINDOW_MINUTES}m, and GitHub API failures alert at most once/hour.`
+      : 'ntfy alerting is DISABLED (NTFY_URL not set). Volume bursts and GitHub failures will only appear in these logs.',
+  );
 }
 
 const app = express();
@@ -93,6 +113,7 @@ app.use((req, res, next) => {
 
 (async () => {
   checkRequiredEnv();
+  logAlertingStatus();
 
   const server = await registerRoutes(app);
 
@@ -102,6 +123,13 @@ app.use((req, res, next) => {
     // Log the full error server-side; never forward internal error detail
     // (stack traces, upstream API URLs, rate-limit info) to the client.
     console.error(`[error] ${req.method} ${req.path} -> ${status}`, err);
+
+    // Best-effort, never fatal: an unhandled exception on any route is a
+    // genuine fault worth having in GlitchTip. This is telemetry, not a
+    // gate, so a reporting failure must never affect the response below.
+    if (status >= 500) {
+      void reportFault({ event: 'unexpected-exception', error: err, tags: { path: req.path, method: req.method } });
+    }
 
     res.status(status).json({ message: "Internal Server Error" });
   });

--- a/server/lib/glitchtip.ts
+++ b/server/lib/glitchtip.ts
@@ -1,0 +1,119 @@
+// Dependency-free client for reporting genuine faults to the self-hosted
+// GlitchTip instance (issue #61). GlitchTip speaks the Sentry "store"
+// protocol, so this is a tiny fetch() POST rather than a full SDK - see
+// the PR description for why @sentry/node was passed over.
+//
+// This is telemetry, not a gate: nothing here may affect the request the
+// caller is serving. Every function is fire-and-forget from the caller's
+// point of view and swallows its own errors, logging them loudly instead
+// (rule: a swallowed exception needs a written reason - the reason is that
+// a reporting failure must never become a user-facing failure).
+//
+// Config is env-only and defaults OFF: absent SENTRY_DSN means
+// errorReportingEnabled is false and reportFault() is a no-op.
+
+import { randomUUID } from 'node:crypto';
+import { logIssueEvent } from './log';
+
+interface ParsedDsn {
+  storeUrl: string;
+  publicKey: string;
+}
+
+// DSN shape: https://<publicKey>@<host>[:port][/path-prefix]/<projectId>
+function parseDsn(dsn: string): ParsedDsn | null {
+  try {
+    const url = new URL(dsn);
+    const publicKey = url.username;
+    const projectId = url.pathname.replace(/^\//, '').replace(/\/$/, '');
+    if (!publicKey || !projectId) {
+      return null;
+    }
+
+    return {
+      storeUrl: `${url.protocol}//${url.host}/api/${projectId}/store/`,
+      publicKey,
+    };
+  } catch {
+    return null;
+  }
+}
+
+const dsn = process.env.SENTRY_DSN;
+const parsedDsn = dsn ? parseDsn(dsn) : null;
+
+if (dsn && !parsedDsn) {
+  // Config error, not a fault to report to GlitchTip (it's unreachable by
+  // definition). Log it loudly so a typo'd DSN doesn't fail silently.
+  logIssueEvent({
+    event: 'alerting-delivery-failed',
+    outcome: 'error',
+    status: 0,
+    channel: 'glitchtip',
+    detail: 'SENTRY_DSN is set but could not be parsed; error reporting disabled',
+  });
+}
+
+export const errorReportingEnabled = parsedDsn !== null;
+
+function normaliseError(error: unknown): { type: string; message: string; stack?: string } {
+  if (error instanceof Error) {
+    return { type: error.name || 'Error', message: error.message, stack: error.stack };
+  }
+  return { type: 'NonErrorThrown', message: String(error) };
+}
+
+export async function reportFault(params: {
+  event: string;
+  error: unknown;
+  tags?: Record<string, string>;
+}): Promise<void> {
+  if (!parsedDsn) {
+    return;
+  }
+
+  try {
+    const { type, message, stack } = normaliseError(params.error);
+
+    const payload = {
+      event_id: randomUUID().replace(/-/g, ''),
+      timestamp: new Date().toISOString(),
+      platform: 'node',
+      level: 'error',
+      logger: 'candr-issues-endpoint',
+      exception: {
+        values: [{ type, value: message }],
+      },
+      extra: stack ? { stack } : undefined,
+      tags: { source: 'issues-endpoint', event: params.event, ...params.tags },
+    };
+
+    const res = await fetch(parsedDsn.storeUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Sentry-Auth': `Sentry sentry_version=7, sentry_client=candr-issues-alerting/1.0, sentry_key=${parsedDsn.publicKey}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!res.ok) {
+      logIssueEvent({
+        event: 'alerting-delivery-failed',
+        outcome: 'error',
+        status: res.status,
+        channel: 'glitchtip',
+      });
+    }
+  } catch (err) {
+    // Best-effort: GlitchTip being unreachable must never affect the
+    // response already sent (or about to be sent) to the caller.
+    logIssueEvent({
+      event: 'alerting-delivery-failed',
+      outcome: 'error',
+      status: 0,
+      channel: 'glitchtip',
+      detail: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/server/lib/log.ts
+++ b/server/lib/log.ts
@@ -1,0 +1,50 @@
+// Structured single-line logging for the bug-report endpoint (issue #61).
+//
+// Each call emits one JSON object per line: timestamp, event, outcome,
+// status, plus a small set of categorical fields (reason, issueNumber,
+// channel, detail). This is deliberately a thin wrapper around
+// console.log/console.error rather than a logging library: one file, one
+// job, easy to swap for a real log pipeline later without touching call
+// sites.
+//
+// NEVER pass report content, screenshot bytes, or tokens through `detail`
+// or any other field here - only diagnostic categories, counts and short
+// error messages. The whole point of this file is that it is safe to ship
+// straight to container logs and, via GlitchTip, off the box.
+
+export type IssueLogEvent =
+  | 'submission-accepted'
+  | 'rejected-validation'
+  | 'rejected-rate-limit'
+  | 'rejected-screenshot'
+  | 'github-api-failure'
+  | 'token-missing'
+  | 'screenshot-upload-failed'
+  | 'alerting-delivery-failed';
+
+export type IssueLogOutcome = 'accepted' | 'rejected' | 'error';
+
+export interface IssueLogFields {
+  event: IssueLogEvent;
+  outcome: IssueLogOutcome;
+  status: number;
+  /** Short reason category, e.g. a Zod issue path or "too-large". Never free text from the payload. */
+  reason?: string;
+  issueNumber?: number;
+  channel?: 'glitchtip' | 'ntfy';
+  /** Short diagnostic string (e.g. an error message). Never report content. */
+  detail?: string;
+}
+
+export function logIssueEvent(fields: IssueLogFields): void {
+  const entry = {
+    timestamp: new Date().toISOString(),
+    ...fields,
+  };
+
+  if (fields.outcome === 'error') {
+    console.error(JSON.stringify(entry));
+  } else {
+    console.log(JSON.stringify(entry));
+  }
+}

--- a/server/lib/ntfy.ts
+++ b/server/lib/ntfy.ts
@@ -1,0 +1,118 @@
+// ntfy alerting for the bug-report endpoint (issue #61): a burst-volume
+// alert (accepted submissions exceeding a threshold within a rolling
+// window - abuse that got past the per-IP rate limit by spreading across
+// clients) and a throttled github-api-failure alert (the GitHub
+// integration is broken, so reports are being lost silently otherwise).
+//
+// Delivery is best-effort and must never block or fail the request it is
+// reporting on. A failed alert can't page anyone by definition, so on
+// failure it is logged loudly instead - the log line is the only trail
+// left. Config is env-only and defaults OFF: absent NTFY_URL means
+// ntfyEnabled is false and both entry points below are no-ops.
+
+import { logIssueEvent } from './log';
+
+function parseIntEnv(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+const NTFY_URL = process.env.NTFY_URL;
+const NTFY_TOKEN = process.env.NTFY_TOKEN;
+export const ntfyEnabled = !!NTFY_URL;
+
+export const BURST_THRESHOLD = parseIntEnv(process.env.NTFY_BURST_THRESHOLD, 10);
+export const BURST_WINDOW_MINUTES = parseIntEnv(process.env.NTFY_BURST_WINDOW_MINUTES, 60);
+const BURST_WINDOW_MS = BURST_WINDOW_MINUTES * 60 * 1000;
+
+// Not configurable: this is a floor against alert fatigue on a channel
+// that pages a person, not a tunable abuse threshold.
+const GITHUB_FAILURE_THROTTLE_MS = 60 * 60 * 1000;
+
+async function publish(title: string, message: string, priority: 'high' | 'default'): Promise<void> {
+  if (!NTFY_URL) {
+    return;
+  }
+
+  try {
+    const headers: Record<string, string> = {
+      Title: title,
+      Priority: priority,
+    };
+    if (NTFY_TOKEN) {
+      headers.Authorization = `Bearer ${NTFY_TOKEN}`;
+    }
+
+    const res = await fetch(NTFY_URL, { method: 'POST', body: message, headers });
+    if (!res.ok) {
+      logIssueEvent({ event: 'alerting-delivery-failed', outcome: 'error', status: res.status, channel: 'ntfy' });
+    }
+  } catch (err) {
+    logIssueEvent({
+      event: 'alerting-delivery-failed',
+      outcome: 'error',
+      status: 0,
+      channel: 'ntfy',
+      detail: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+// --- Burst tracking -------------------------------------------------------
+//
+// Rolling window of accepted-submission timestamps, held in memory (resets
+// on redeploy, same as the rate limiter this complements - acceptable at
+// this traffic level). Fires once when the count first crosses the
+// threshold, then re-arms only once the window has quieted back under
+// threshold, so a sustained burst pages once, not once per submission.
+
+let acceptedTimestamps: number[] = [];
+let burstArmed = true;
+
+export function recordAcceptedSubmission(): void {
+  if (!NTFY_URL) {
+    return;
+  }
+
+  const now = Date.now();
+  acceptedTimestamps.push(now);
+  acceptedTimestamps = acceptedTimestamps.filter((t) => now - t <= BURST_WINDOW_MS);
+
+  if (acceptedTimestamps.length > BURST_THRESHOLD) {
+    if (burstArmed) {
+      burstArmed = false;
+      void publish(
+        'Chores and Rewards: report volume alert',
+        `${acceptedTimestamps.length} bug/feature reports accepted in the last ${BURST_WINDOW_MINUTES} minutes (threshold ${BURST_THRESHOLD}). Check for abuse.`,
+        'high',
+      );
+    }
+  } else {
+    burstArmed = true;
+  }
+}
+
+// --- GitHub API failure alert, throttled to at most one per hour ---------
+
+let lastGithubFailureAlertAt = 0;
+
+export function alertGithubApiFailure(): void {
+  if (!NTFY_URL) {
+    return;
+  }
+
+  const now = Date.now();
+  if (now - lastGithubFailureAlertAt < GITHUB_FAILURE_THROTTLE_MS) {
+    return;
+  }
+  lastGithubFailureAlertAt = now;
+
+  void publish(
+    'Chores and Rewards: GitHub integration failing',
+    'The bug-report endpoint is failing to reach the GitHub API. Reports may be getting lost. Check container logs.',
+    'high',
+  );
+}

--- a/server/routes/issues.ts
+++ b/server/routes/issues.ts
@@ -2,6 +2,9 @@ import { Router, type Request, type Response } from 'express';
 import { Octokit } from '@octokit/rest';
 import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import { bugReportSchema } from '../../shared/schema';
+import { logIssueEvent } from '../lib/log';
+import { reportFault } from '../lib/glitchtip';
+import { recordAcceptedSubmission, alertGithubApiFailure } from '../lib/ntfy';
 
 const router = Router();
 
@@ -59,7 +62,6 @@ const createIssueLimiter = rateLimit({
   limit: 5,
   standardHeaders: true,
   legacyHeaders: false,
-  message: { message: 'Too many reports submitted. Please try again later.' },
   keyGenerator: (req) => {
     const cfIp = req.headers['cf-connecting-ip'];
     if (typeof cfIp === 'string' && cfIp.length > 0) {
@@ -67,12 +69,20 @@ const createIssueLimiter = rateLimit({
     }
     return ipKeyGenerator(req.ip ?? '');
   },
+  handler: (_req, res) => {
+    logIssueEvent({ event: 'rejected-rate-limit', outcome: 'rejected', status: 429 });
+    res.status(429).json({ message: 'Too many reports submitted. Please try again later.' });
+  },
 });
 
 // POST /api/issues/create
 router.post('/create', createIssueLimiter, async (req: Request, res: Response) => {
   const parseResult = bugReportSchema.safeParse(req.body);
   if (!parseResult.success) {
+    // Reason category only (which field/rule failed), never the submitted
+    // values themselves.
+    const reason = parseResult.error.issues[0]?.path.join('.') || 'unknown';
+    logIssueEvent({ event: 'rejected-validation', outcome: 'rejected', status: 400, reason });
     return res.status(400).json({
       message: 'Invalid bug report payload.',
     });
@@ -97,12 +107,14 @@ router.post('/create', createIssueLimiter, async (req: Request, res: Response) =
     const decoded = Buffer.from(base64Data, 'base64');
 
     if (decoded.length > MAX_SCREENSHOT_BYTES) {
+      logIssueEvent({ event: 'rejected-screenshot', outcome: 'rejected', status: 400, reason: 'too-large' });
       return res.status(400).json({
         message: 'Screenshot is too large.',
       });
     }
 
     if (!detectImageType(decoded)) {
+      logIssueEvent({ event: 'rejected-screenshot', outcome: 'rejected', status: 400, reason: 'unrecognised-format' });
       return res.status(400).json({
         message: 'Screenshot does not look like a valid image.',
       });
@@ -112,7 +124,7 @@ router.post('/create', createIssueLimiter, async (req: Request, res: Response) =
   }
 
   if (!GITHUB_TOKEN) {
-    console.error('GITHUB_TOKEN not configured; refusing bug report submission');
+    logIssueEvent({ event: 'token-missing', outcome: 'rejected', status: 503 });
     return res.status(503).json({
       message: 'Bug reporting is temporarily unavailable. Please contact support.',
     });
@@ -173,7 +185,8 @@ router.post('/create', createIssueLimiter, async (req: Request, res: Response) =
     });
 
     const issueNumber = issueResponse.data.number;
-    console.log(`Created issue #${issueNumber}: ${title}`);
+    logIssueEvent({ event: 'submission-accepted', outcome: 'accepted', status: 201, issueNumber });
+    recordAcceptedSubmission();
 
     // Handle screenshot upload if provided (already content-validated above)
     if (screenshotBase64) {
@@ -229,9 +242,18 @@ router.post('/create', createIssueLimiter, async (req: Request, res: Response) =
           body: `**Screenshot**: ${screenshotUrl}`,
         });
 
-        console.log(`Uploaded screenshot for issue #${issueNumber}`);
       } catch (screenshotError) {
-        console.error('Failed to upload screenshot:', screenshotError);
+        logIssueEvent({
+          event: 'screenshot-upload-failed',
+          outcome: 'error',
+          status: 201,
+          issueNumber,
+          detail: screenshotError instanceof Error ? screenshotError.message : String(screenshotError),
+        });
+        // Best-effort fault report: the issue itself was created fine, so
+        // this must never turn into a failed request.
+        void reportFault({ event: 'screenshot-upload-failed', error: screenshotError, tags: { issueNumber: String(issueNumber) } });
+
         // Don't fail the whole request if screenshot upload fails
         await octokit.issues.createComment({
           owner: GITHUB_REPO_OWNER,
@@ -248,7 +270,18 @@ router.post('/create', createIssueLimiter, async (req: Request, res: Response) =
       url: issueResponse.data.html_url,
     });
   } catch (error) {
-    console.error('Error creating GitHub issue:', error);
+    logIssueEvent({
+      event: 'github-api-failure',
+      outcome: 'error',
+      status: 500,
+      detail: error instanceof Error ? error.message : String(error),
+    });
+    // Genuine fault: the GitHub API call itself failed, so reports may be
+    // getting lost. Report it (best-effort) and alert (throttled), since
+    // otherwise this is invisible until someone notices no issues arriving.
+    void reportFault({ event: 'github-api-failure', error });
+    alertGithubApiFailure();
+
     res.status(500).json({
       message: 'Failed to create issue. Please try again.',
     });


### PR DESCRIPTION
Closes #61

## Summary

The bug-report endpoint's only logging was a truncated request line at `server/index.ts:20-34`; rejected submissions, GitHub failures and abuse bursts were invisible unless someone happened to be watching the repo. This adds:

- **Structured logging** (`server/lib/log.ts`): one JSON line per outcome, covering `submission-accepted`, `rejected-validation`, `rejected-rate-limit`, `rejected-screenshot`, `token-missing`, `github-api-failure`, plus `screenshot-upload-failed` and `alerting-delivery-failed` as extras found while wiring this up. Report content, screenshot bytes and tokens are never logged, only categories, counts and short diagnostic strings.
- **GlitchTip fault reporting** (`server/lib/glitchtip.ts`): a small dependency-free `fetch()` client against GlitchTip's Sentry-compatible store endpoint. Reports only genuine faults: `github-api-failure` and unhandled exceptions (wired into the app-wide error handler in `server/index.ts` too, for free, since any 5xx there is exactly this kind of fault). Best-effort throughout: delivery failure is logged, never allowed to affect the response already being sent.
- **ntfy alerting** (`server/lib/ntfy.ts`): a single high-priority alert when accepted submissions exceed `NTFY_BURST_THRESHOLD` (default 10) within a rolling `NTFY_BURST_WINDOW_MINUTES` (default 60), re-arming only once the window quiets. Separately, a github-api-failure alert throttled to at most one per hour, since a broken GitHub integration otherwise loses reports silently. Same best-effort/log-loudly-on-failure behaviour.
- **Startup visibility** (`server/index.ts`): one log line each stating whether error reporting and ntfy alerting are enabled or disabled, so a misconfigured deploy is visible in `docker logs` immediately.
- **Docs**: `.env.example` documents the five new optional vars; `docs/security/alerting-setup.md` is the operator runbook; `docs/security/threat-model-issues-endpoint.md` updated to reflect the new controls and residual gaps.

All of it is env-gated and defaults off. Absent `SENTRY_DSN` / `NTFY_URL`, the app behaves exactly as before, with one log line at startup confirming that.

## GlitchTip approach: fetch-based, not @sentry/node

Went with a ~90-line dependency-free client over the official SDK. Reasoning:

- Only two event categories need reporting (`github-api-failure`, unexpected exceptions), with a handful of tags. That's a POST to the Sentry "store" endpoint with an `X-Sentry-Auth` header, not something that needs breadcrumbs, performance tracing, release health or the SDK's global exception hooks.
- This repo (per CONTRIBUTING.md / the recent audit) has been actively fighting its dependency count down. Adding a full instrumentation SDK for two event types cuts against that.
- The fetch client is trivial to read end to end in one sitting, which matters for a security-relevant path (it's telemetry off the same endpoint the threat model already tracks).

If reporting needs grow (breadcrumbs, distributed tracing, more event types), `@sentry/node` becomes the better trade and this file is small enough to throw away without regret.

## Environment variables an operator must set

None are required; the app runs unchanged with none of them set. To enable:

| Variable | Default | Purpose |
|---|---|---|
| `SENTRY_DSN` | (none) | GlitchTip project DSN; enables fault reporting |
| `NTFY_URL` | (none) | ntfy topic URL; enables burst + GitHub-failure alerts |
| `NTFY_TOKEN` | (none) | Bearer token if the ntfy topic requires auth |
| `NTFY_BURST_THRESHOLD` | `10` | Accepted-submission count that triggers a burst alert |
| `NTFY_BURST_WINDOW_MINUTES` | `60` | Rolling window the threshold is measured over |

Full detail in `docs/security/alerting-setup.md`.

## Verification

`pnpm install`, `pnpm run check` (tsc, clean), `pnpm run build` (vite + esbuild, clean) and `pnpm run test` (17/17 passing, unchanged) all pass.

Local smoke tests, run against the actual built/source modules (not reimplementations):

- **Boots clean with no env set**: ran `dist/index.js` with none of `GITHUB_TOKEN` / `SENTRY_DSN` / `NTFY_URL` set. Logs the existing GITHUB_TOKEN warning plus two new lines confirming error reporting and ntfy alerting are both DISABLED, then serves normally.
- **Burst alert**: drove `recordAcceptedSubmission()` from `server/lib/ntfy.ts` directly 12 times in a row against a local Python HTTP listener standing in for ntfy, with `NTFY_BURST_THRESHOLD=10`. Exactly one POST arrived, on the 11th call (crossing the threshold), title `Chores and Rewards: report volume alert`, `Priority: high`, ASCII-only. The 12th call did not re-fire (not yet re-armed). I drove `recordAcceptedSubmission()` directly rather than the full HTTP endpoint because a real accepted submission requires a live `GITHUB_TOKEN` and would create a real issue on `candr-reports` per call; this exercises the exact function `issues.ts` calls on every accepted submission.
- **GitHub-failure alert throttling**: called `alertGithubApiFailure()` three times in a row against the same fake listener. Exactly one POST arrived (`Chores and Rewards: GitHub integration failing`, `Priority: high`), confirming the one-per-hour throttle. Also verified with `NTFY_TOKEN` set that the request carries `Authorization: Bearer <token>`.
- **GlitchTip client**: called `reportFault()` against a local Python HTTP listener standing in for GlitchTip's store endpoint with `SENTRY_DSN=http://fakekey@127.0.0.1:PORT/1`. Confirmed the DSN parses to `POST /api/1/store/` with a valid `X-Sentry-Auth: Sentry sentry_version=7, sentry_client=candr-issues-alerting/1.0, sentry_key=fakekey` header and a well-formed Sentry event body (`exception.values[0].type/value`, `extra.stack`, `tags`).

All scratch listener scripts and log files were deleted after use; nothing from the smoke tests is committed.