### PR TITLE
Client bundle: completions ledger, import safety, undo, parent PIN

### DIFF
--- a/client/src/components/PinPromptDialog.tsx
+++ b/client/src/components/PinPromptDialog.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { verifyPin } from '@/lib/pin';
+
+interface PinPromptDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onVerified: () => void;
+  pinHash?: string;
+  pinSalt?: string;
+}
+
+// Reusable "enter the parent PIN to continue" gate, driven by
+// hooks/use-pin-guard.ts. Rendered once per gated page; usePinGuard decides
+// whether it needs to open at all.
+export default function PinPromptDialog({ open, onOpenChange, onVerified, pinHash, pinSalt }: PinPromptDialogProps) {
+  const [pin, setPin] = useState('');
+  const [error, setError] = useState('');
+  const [checking, setChecking] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setPin('');
+      setError('');
+      setChecking(false);
+    }
+  }, [open]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!pinHash || !pinSalt) {
+      // No PIN configured to check against; nothing should have opened this
+      // dialog, but let the caller through rather than trap them.
+      onVerified();
+      return;
+    }
+
+    setChecking(true);
+    const ok = await verifyPin(pin, pinSalt, pinHash);
+    setChecking(false);
+
+    if (ok) {
+      onVerified();
+    } else {
+      setError('Incorrect PIN');
+      setPin('');
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="text-xl font-semibold text-brand-grayDark">Enter Parent PIN</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <Label htmlFor="pin-prompt-input" className="block text-sm font-medium text-brand-grayDark mb-2">
+              PIN
+            </Label>
+            <Input
+              id="pin-prompt-input"
+              type="password"
+              inputMode="numeric"
+              autoComplete="off"
+              autoFocus
+              maxLength={6}
+              value={pin}
+              onChange={(e) => setPin(e.target.value.replace(/\D/g, ''))}
+              className="w-full"
+              data-testid="input-pin-prompt"
+            />
+            {error && (
+              <p className="text-brand-coral text-sm mt-2" data-testid="text-pin-prompt-error">
+                {error}
+              </p>
+            )}
+          </div>
+          <div className="flex gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              className="flex-1"
+              data-testid="button-cancel-pin-prompt"
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={checking || pin.length < 4}
+              className="flex-1 bg-brand-teal hover:bg-brand-teal/90"
+              data-testid="button-confirm-pin-prompt"
+            >
+              {checking ? 'Checking...' : 'Confirm'}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/PinSetupDialog.tsx
+++ b/client/src/components/PinSetupDialog.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useSettings, useUpdateSettings } from '@/hooks/use-app-data';
+import { useToast } from '@/hooks/use-toast';
+import { generateSalt, hashPin, verifyPin } from '@/lib/pin';
+
+interface PinSetupDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const PIN_PATTERN = /^\d{4,6}$/;
+
+// Set, change or remove the parent PIN from SettingsPage. Changing or
+// removing an existing PIN requires re-entering the current one first;
+// setting a fresh PIN (none configured yet) skips straight to the new-PIN
+// fields.
+export default function PinSetupDialog({ open, onOpenChange }: PinSetupDialogProps) {
+  const { data: settings } = useSettings();
+  const updateSettings = useUpdateSettings();
+  const { toast } = useToast();
+
+  const hasPin = !!(settings?.pinHash && settings?.pinSalt);
+
+  const [currentPin, setCurrentPin] = useState('');
+  const [newPin, setNewPin] = useState('');
+  const [confirmPin, setConfirmPin] = useState('');
+  const [error, setError] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setCurrentPin('');
+      setNewPin('');
+      setConfirmPin('');
+      setError('');
+      setBusy(false);
+    }
+  }, [open]);
+
+  const currentPinIsCorrect = async (): Promise<boolean> => {
+    if (!hasPin) return true;
+    if (!settings?.pinHash || !settings?.pinSalt) return true;
+    return verifyPin(currentPin, settings.pinSalt, settings.pinHash);
+  };
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    if (!(await currentPinIsCorrect())) {
+      setError('Current PIN is incorrect');
+      return;
+    }
+
+    if (!PIN_PATTERN.test(newPin)) {
+      setError('PIN must be 4 to 6 digits');
+      return;
+    }
+    if (newPin !== confirmPin) {
+      setError('PINs do not match');
+      return;
+    }
+
+    setBusy(true);
+    try {
+      const salt = generateSalt();
+      const pinHash = await hashPin(newPin, salt);
+      await updateSettings.mutateAsync({ ...settings!, pinHash, pinSalt: salt });
+      toast({ title: "Success", description: hasPin ? "PIN updated" : "Parent PIN set" });
+      onOpenChange(false);
+    } catch {
+      toast({ title: "Error", description: "Failed to save the PIN", variant: "destructive" });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleRemove = async () => {
+    setError('');
+    if (!(await currentPinIsCorrect())) {
+      setError('Current PIN is incorrect');
+      return;
+    }
+
+    setBusy(true);
+    try {
+      const { pinHash: _pinHash, pinSalt: _pinSalt, ...withoutPin } = settings!;
+      await updateSettings.mutateAsync(withoutPin);
+      toast({ title: "Success", description: "PIN removed" });
+      onOpenChange(false);
+    } catch {
+      toast({ title: "Error", description: "Failed to remove the PIN", variant: "destructive" });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="text-xl font-semibold text-brand-grayDark">
+            {hasPin ? 'Change Parent PIN' : 'Set Parent PIN'}
+          </DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSave} className="space-y-4">
+          {hasPin && (
+            <div>
+              <Label htmlFor="pin-setup-current" className="block text-sm font-medium text-brand-grayDark mb-2">
+                Current PIN
+              </Label>
+              <Input
+                id="pin-setup-current"
+                type="password"
+                inputMode="numeric"
+                autoComplete="off"
+                maxLength={6}
+                value={currentPin}
+                onChange={(e) => setCurrentPin(e.target.value.replace(/\D/g, ''))}
+                className="w-full"
+                data-testid="input-pin-current"
+              />
+            </div>
+          )}
+          <div>
+            <Label htmlFor="pin-setup-new" className="block text-sm font-medium text-brand-grayDark mb-2">
+              New PIN (4-6 digits)
+            </Label>
+            <Input
+              id="pin-setup-new"
+              type="password"
+              inputMode="numeric"
+              autoComplete="off"
+              maxLength={6}
+              value={newPin}
+              onChange={(e) => setNewPin(e.target.value.replace(/\D/g, ''))}
+              className="w-full"
+              data-testid="input-pin-new"
+            />
+          </div>
+          <div>
+            <Label htmlFor="pin-setup-confirm" className="block text-sm font-medium text-brand-grayDark mb-2">
+              Confirm New PIN
+            </Label>
+            <Input
+              id="pin-setup-confirm"
+              type="password"
+              inputMode="numeric"
+              autoComplete="off"
+              maxLength={6}
+              value={confirmPin}
+              onChange={(e) => setConfirmPin(e.target.value.replace(/\D/g, ''))}
+              className="w-full"
+              data-testid="input-pin-confirm"
+            />
+          </div>
+          {error && (
+            <p className="text-brand-coral text-sm" data-testid="text-pin-setup-error">
+              {error}
+            </p>
+          )}
+          <div className="flex gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              className="flex-1"
+              data-testid="button-cancel-pin-setup"
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={busy}
+              className="flex-1 bg-brand-teal hover:bg-brand-teal/90"
+              data-testid="button-save-pin"
+            >
+              {busy ? 'Saving...' : (hasPin ? 'Update PIN' : 'Set PIN')}
+            </Button>
+          </div>
+          {hasPin && (
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={handleRemove}
+              disabled={busy}
+              className="w-full text-brand-coral/70 hover:text-brand-coral hover:bg-brand-coral/10"
+              data-testid="button-remove-pin"
+            >
+              Remove PIN
+            </Button>
+          )}
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/hooks/use-app-data.ts
+++ b/client/src/hooks/use-app-data.ts
@@ -127,6 +127,18 @@ export function useCompleteChore() {
   });
 }
 
+export function useUndoCompletion() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (completionId: string) => storage.undoCompletion(completionId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['children'] });
+      queryClient.invalidateQueries({ queryKey: ['completions'] });
+    },
+  });
+}
+
 export function usePayoutChild() {
   const queryClient = useQueryClient();
   

--- a/client/src/hooks/use-app-data.ts
+++ b/client/src/hooks/use-app-data.ts
@@ -31,6 +31,13 @@ export function usePayouts() {
   });
 }
 
+export function useCompletions() {
+  return useQuery({
+    queryKey: ['completions'],
+    queryFn: () => storage.getAllCompletions(),
+  });
+}
+
 export function useSettings() {
   return useQuery({
     queryKey: ['settings'],
@@ -109,12 +116,13 @@ export function useDeleteChore() {
 
 export function useCompleteChore() {
   const queryClient = useQueryClient();
-  
+
   return useMutation({
-    mutationFn: ({ childId, choreValueCents }: { childId: string; choreValueCents: number }) => 
-      storage.completeChore(childId, choreValueCents),
+    mutationFn: ({ childId, choreId, choreTitle, choreValueCents }: { childId: string; choreId: string; choreTitle: string; choreValueCents: number }) =>
+      storage.completeChore(childId, choreId, choreTitle, choreValueCents),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['children'] });
+      queryClient.invalidateQueries({ queryKey: ['completions'] });
     },
   });
 }

--- a/client/src/hooks/use-pin-guard.ts
+++ b/client/src/hooks/use-pin-guard.ts
@@ -1,0 +1,44 @@
+import { useCallback, useRef, useState } from 'react';
+import { useSettings } from '@/hooks/use-app-data';
+import { isPinGraceActive, markPinVerified } from '@/lib/pin';
+
+// Wraps a parent-only action so it runs immediately when no PIN is set, or
+// when the parent verified a PIN recently enough to still be in the grace
+// window (see lib/pin.ts), and otherwise pops a PinPromptDialog first. One
+// instance per gated site (ChildChoresPage, TotalsPage, ChoresPage,
+// SettingsPage each hold their own), all sharing the same in-memory grace
+// window so a parent who verified on one page isn't re-prompted on another
+// within five minutes.
+export function usePinGuard() {
+  const { data: settings } = useSettings();
+  const [open, setOpen] = useState(false);
+  const pendingAction = useRef<(() => void) | null>(null);
+
+  const guard = useCallback((action: () => void) => {
+    if (!settings?.pinHash || !settings?.pinSalt || isPinGraceActive()) {
+      action();
+      return;
+    }
+    pendingAction.current = action;
+    setOpen(true);
+  }, [settings?.pinHash, settings?.pinSalt]);
+
+  const handleVerified = useCallback(() => {
+    markPinVerified();
+    setOpen(false);
+    const action = pendingAction.current;
+    pendingAction.current = null;
+    action?.();
+  }, []);
+
+  return {
+    guard,
+    pinPromptProps: {
+      open,
+      onOpenChange: setOpen,
+      onVerified: handleVerified,
+      pinHash: settings?.pinHash,
+      pinSalt: settings?.pinSalt,
+    },
+  };
+}

--- a/client/src/lib/db.ts
+++ b/client/src/lib/db.ts
@@ -1,5 +1,5 @@
 import { openDB, DBSchema, IDBPDatabase } from 'idb';
-import { Child, Chore, Payout, Settings } from '@shared/schema';
+import { Child, Chore, Payout, Completion, Settings } from '@shared/schema';
 import { nanoid } from 'nanoid';
 
 interface ChoresDB extends DBSchema {
@@ -14,6 +14,10 @@ interface ChoresDB extends DBSchema {
   payouts: {
     key: string;
     value: Payout;
+  };
+  completions: {
+    key: string;
+    value: Completion;
   };
   settings: {
     key: string;
@@ -34,7 +38,7 @@ export async function getDB(): Promise<IDBPDatabase<ChoresDB>> {
   }
 
   dbPromise = (async () => {
-    const db = await openDB<ChoresDB>('chores-rewards-db', 2, {
+    const db = await openDB<ChoresDB>('chores-rewards-db', 3, {
       upgrade(db, oldVersion) {
         // Children store
         if (!db.objectStoreNames.contains('children')) {
@@ -49,6 +53,15 @@ export async function getDB(): Promise<IDBPDatabase<ChoresDB>> {
         // Payouts store
         if (!db.objectStoreNames.contains('payouts')) {
           db.createObjectStore('payouts', { keyPath: 'id' });
+        }
+
+        // Completions store (added in v3): one row per chore completion, so
+        // "N done" counts can be derived instead of estimated. The contains()
+        // guard means an existing v1/v2 database only gains this store; the
+        // children/chores/payouts/settings stores it already has are left
+        // untouched and their data survives the upgrade.
+        if (!db.objectStoreNames.contains('completions')) {
+          db.createObjectStore('completions', { keyPath: 'id' });
         }
 
         // Settings store

--- a/client/src/lib/import-scope.ts
+++ b/client/src/lib/import-scope.ts
@@ -1,0 +1,27 @@
+// Pure helpers for the import confirmation dialog (see SettingsPage). Kept
+// separate from the page so the scope-naming and empty-database logic can be
+// unit tested without rendering React.
+
+export interface ImportScopeCounts {
+  children: number;
+  chores: number;
+  payouts: number;
+}
+
+// The confirmation dialog (and the automatic pre-import backup) is only
+// shown when there is existing data that an import would destroy. A brand
+// new database is not "empty" in the loose sense the moment default chores
+// have been seeded, but it has nothing a user would recognise as data worth
+// naming yet, so we only skip the dialog when children, chores and payouts
+// are all genuinely empty.
+export function isDataEmpty(counts: ImportScopeCounts): boolean {
+  return counts.children === 0 && counts.chores === 0 && counts.payouts === 0;
+}
+
+function pluralize(count: number, singular: string, plural: string): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+export function describeImportScope(counts: ImportScopeCounts): string {
+  return `Replace ${pluralize(counts.children, 'child', 'children')}, ${pluralize(counts.chores, 'chore', 'chores')} and ${pluralize(counts.payouts, 'payout', 'payouts')}?`;
+}

--- a/client/src/lib/pin.ts
+++ b/client/src/lib/pin.ts
@@ -1,0 +1,48 @@
+// Parent PIN hashing and the in-memory "recently verified" grace window.
+//
+// This is kid-proofing, not cryptography: it stops a child from casually
+// reading the PIN out of IndexedDB, not a real access-control boundary
+// against a determined adult with devtools open. SHA-256 with a per-install
+// random salt is plenty for that bar and needs no dependency beyond
+// WebCrypto, which every browser this PWA targets already has.
+
+const PIN_GRACE_PERIOD_MS = 5 * 60 * 1000;
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes).map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+export function generateSalt(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  return bytesToHex(bytes);
+}
+
+export async function hashPin(pin: string, salt: string): Promise<string> {
+  const encoded = new TextEncoder().encode(`${salt}:${pin}`);
+  const digest = await crypto.subtle.digest('SHA-256', encoded);
+  return bytesToHex(new Uint8Array(digest));
+}
+
+export async function verifyPin(pin: string, salt: string, expectedHash: string): Promise<boolean> {
+  const computed = await hashPin(pin, salt);
+  return computed === expectedHash;
+}
+
+// Module-level (not persisted) so a parent who has just entered the PIN
+// isn't asked again for every gated action within the grace window, but a
+// page reload or app restart always re-prompts.
+let lastVerifiedAt: number | null = null;
+
+export function markPinVerified(): void {
+  lastVerifiedAt = Date.now();
+}
+
+export function isPinGraceActive(): boolean {
+  return lastVerifiedAt !== null && Date.now() - lastVerifiedAt < PIN_GRACE_PERIOD_MS;
+}
+
+// Test-only escape hatch: resets the grace window so cases can be exercised
+// independently of real wall-clock time.
+export function resetPinGraceForTests(): void {
+  lastVerifiedAt = null;
+}

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -1,5 +1,5 @@
 import { getDB } from './db';
-import { Child, Chore, Payout, Settings, InsertChild, InsertChore, InsertPayout, AppData } from '@shared/schema';
+import { Child, Chore, Payout, Completion, Settings, InsertChild, InsertChore, InsertPayout, AppData } from '@shared/schema';
 import { nanoid } from 'nanoid';
 
 // idb creates a transaction's `tx.done` promise as soon as the transaction
@@ -88,19 +88,27 @@ export class AppStorage {
 
   async deleteChild(id: string): Promise<void> {
     const db = await getDB();
-    const tx = db.transaction(['children', 'payouts'], 'readwrite');
+    const tx = db.transaction(['children', 'payouts', 'completions'], 'readwrite');
     const childrenStore = tx.objectStore('children');
     const payoutsStore = tx.objectStore('payouts');
+    const completionsStore = tx.objectStore('completions');
 
     await withTransaction(tx, async () => {
       await childrenStore.delete(id);
 
-      // Also delete all payouts for this child, in the same transaction so
-      // the child and their payout history are removed together or not at all.
+      // Also delete all payouts and completions for this child, in the same
+      // transaction so the child and their history are removed together or
+      // not at all.
       const allPayouts = await payoutsStore.getAll();
       const childPayouts = allPayouts.filter(p => p.childId === id);
       for (const payout of childPayouts) {
         await payoutsStore.delete(payout.id);
+      }
+
+      const allCompletions = await completionsStore.getAll();
+      const childCompletions = allCompletions.filter(c => c.childId === id);
+      for (const completion of childCompletions) {
+        await completionsStore.delete(completion.id);
       }
     });
   }
@@ -190,6 +198,15 @@ export class AppStorage {
     return payout;
   }
 
+  // Completion operations
+  async getAllCompletions(): Promise<Completion[]> {
+    const db = await getDB();
+    const completions = await db.getAll('completions');
+    return completions
+      .map(coerceDate)
+      .sort((a: Completion, b: Completion) => b.createdAt.getTime() - a.createdAt.getTime());
+  }
+
   // Settings operations
   async getSettings(): Promise<Settings> {
     try {
@@ -215,10 +232,11 @@ export class AppStorage {
 
   // Data export/import
   async exportData(): Promise<AppData> {
-    const [children, chores, payouts, settings] = await Promise.all([
+    const [children, chores, payouts, completions, settings] = await Promise.all([
       this.getAllChildren(),
       this.getAllChores(),
       this.getAllPayouts(),
+      this.getAllCompletions(),
       this.getSettings(),
     ]);
 
@@ -226,6 +244,7 @@ export class AppStorage {
       children,
       chores,
       payouts,
+      completions,
       settings,
       exportedAt: new Date(),
     };
@@ -233,13 +252,16 @@ export class AppStorage {
 
   // `data` is expected to have already been validated (and its date fields
   // coerced) by appDataSchema.safeParse at the call site (see SettingsPage's
-  // handleImport), so it's safe to write as-is.
+  // handleImport), so it's safe to write as-is. `data.completions` defaults
+  // to [] via appDataSchema, so a legacy backup taken before completions
+  // existed still imports cleanly.
   async importData(data: AppData): Promise<void> {
     const db = await getDB();
-    const tx = db.transaction(['children', 'chores', 'payouts'], 'readwrite');
+    const tx = db.transaction(['children', 'chores', 'payouts', 'completions'], 'readwrite');
     const childrenStore = tx.objectStore('children');
     const choresStore = tx.objectStore('chores');
     const payoutsStore = tx.objectStore('payouts');
+    const completionsStore = tx.objectStore('completions');
 
     await withTransaction(tx, async () => {
       // Clear existing data and repopulate inside the same transaction, so a
@@ -248,6 +270,7 @@ export class AppStorage {
       await childrenStore.clear();
       await choresStore.clear();
       await payoutsStore.clear();
+      await completionsStore.clear();
 
       for (const child of data.children) {
         await childrenStore.add(child);
@@ -258,6 +281,9 @@ export class AppStorage {
       for (const payout of data.payouts) {
         await payoutsStore.add(payout);
       }
+      for (const completion of data.completions) {
+        await completionsStore.add(completion);
+      }
     });
 
     // Settings live in a separate store and are written after the main
@@ -266,22 +292,76 @@ export class AppStorage {
   }
 
   // Utility methods
-  async completeChore(childId: string, choreValueCents: number): Promise<Child> {
+  // Atomically increments the child's balance and records the completion
+  // that earned it, in one transaction, so a completion can never exist
+  // without the balance reflecting it (or vice versa). choreTitle is a
+  // snapshot: chores are deletable, so the completion needs its own copy of
+  // the title to stay meaningful after the chore itself is gone.
+  async completeChore(childId: string, choreId: string, choreTitle: string, valueCents: number): Promise<{ child: Child; completion: Completion }> {
     const db = await getDB();
-    const tx = db.transaction('children', 'readwrite');
-    const store = tx.objectStore('children');
+    const tx = db.transaction(['children', 'completions'], 'readwrite');
+    const childrenStore = tx.objectStore('children');
+    const completionsStore = tx.objectStore('completions');
 
     return withTransaction(tx, async () => {
-      const child = await store.get(childId);
+      const child = await childrenStore.get(childId);
       if (!child) {
         throw new Error('Child not found');
       }
 
       const updatedChild: Child = {
         ...child,
-        totalCents: child.totalCents + choreValueCents,
+        totalCents: child.totalCents + valueCents,
       };
-      await store.put(updatedChild);
+      await childrenStore.put(updatedChild);
+
+      const completion: Completion = {
+        id: nanoid(),
+        childId,
+        choreId,
+        choreTitle,
+        valueCents,
+        createdAt: new Date(),
+      };
+      await completionsStore.add(completion);
+
+      return { child: updatedChild, completion };
+    });
+  }
+
+  // Reverses a single completion: deletes the completion row and gives back
+  // its value in one transaction. Refuses (without touching either store) if
+  // the child's current balance is lower than the completion's value, which
+  // means a payout happened since the completion and undoing it would drive
+  // the balance negative.
+  async undoCompletion(completionId: string): Promise<Child> {
+    const db = await getDB();
+    const tx = db.transaction(['children', 'completions'], 'readwrite');
+    const childrenStore = tx.objectStore('children');
+    const completionsStore = tx.objectStore('completions');
+
+    return withTransaction(tx, async () => {
+      const completion = await completionsStore.get(completionId);
+      if (!completion) {
+        throw new Error('Completion not found');
+      }
+
+      const child = await childrenStore.get(completion.childId);
+      if (!child) {
+        throw new Error('Child not found');
+      }
+
+      if (child.totalCents < completion.valueCents) {
+        throw new Error('Cannot undo: a payout has already happened since this chore was completed');
+      }
+
+      await completionsStore.delete(completionId);
+
+      const updatedChild: Child = {
+        ...child,
+        totalCents: child.totalCents - completion.valueCents,
+      };
+      await childrenStore.put(updatedChild);
 
       return updatedChild;
     });
@@ -306,7 +386,6 @@ export class AppStorage {
       const payout: Payout = {
         id: nanoid(),
         childId: child.id,
-        childName: child.name,
         amountCents: child.totalCents,
         createdAt: new Date(),
       };

--- a/client/src/pages/ChildChoresPage.tsx
+++ b/client/src/pages/ChildChoresPage.tsx
@@ -1,9 +1,10 @@
 import { useState, useMemo, useEffect } from 'react';
 import { useLocation } from 'wouter';
-import { useChild, useChores, useCompleteChore, useDeleteChore, useSettings, useToggleFavoriteChore } from '@/hooks/use-app-data';
+import { useChild, useChores, useCompleteChore, useUndoCompletion, useDeleteChore, useSettings, useToggleFavoriteChore } from '@/hooks/use-app-data';
 import { useFeedback } from '@/hooks/use-feedback';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { ToastAction } from '@/components/ui/toast';
 import { useToast } from '@/hooks/use-toast';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import PayoutDialog from '@/components/PayoutDialog';
@@ -27,6 +28,7 @@ export default function ChildChoresPage({ childId }: ChildChoresPageProps) {
   const { data: chores, isLoading: choresLoading } = useChores();
   const { data: settings } = useSettings();
   const completeChore = useCompleteChore();
+  const undoCompletion = useUndoCompletion();
   const deleteChore = useDeleteChore();
   const toggleFavorite = useToggleFavoriteChore(childId);
   const { choreFeedback } = useFeedback();
@@ -66,17 +68,38 @@ export default function ChildChoresPage({ childId }: ChildChoresPageProps) {
     if (!child) return;
 
     try {
-      await completeChore.mutateAsync({ childId: child.id, choreId, choreTitle, choreValueCents });
+      const { completion } = await completeChore.mutateAsync({ childId: child.id, choreId, choreTitle, choreValueCents });
       await choreFeedback();
 
       toast({
         title: "🎉 Great job!",
         description: `${choreTitle} completed! +${formatValueDisplay(choreValueCents)}`,
+        action: (
+          <ToastAction altText="Undo" onClick={() => handleUndoCompletion(completion.id, choreTitle)}>
+            Undo
+          </ToastAction>
+        ),
       });
     } catch (error) {
       toast({
         title: "Error",
         description: "Failed to complete chore",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleUndoCompletion = async (completionId: string, choreTitle: string) => {
+    try {
+      await undoCompletion.mutateAsync(completionId);
+      toast({
+        title: "Undone",
+        description: `"${choreTitle}" completion has been undone`,
+      });
+    } catch (error) {
+      toast({
+        title: "Can't undo",
+        description: error instanceof Error ? error.message : "Failed to undo the completion",
         variant: "destructive",
       });
     }

--- a/client/src/pages/ChildChoresPage.tsx
+++ b/client/src/pages/ChildChoresPage.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useEffect } from 'react';
 import { useLocation } from 'wouter';
 import { useChild, useChores, useCompleteChore, useUndoCompletion, useDeleteChore, useSettings, useToggleFavoriteChore } from '@/hooks/use-app-data';
 import { useFeedback } from '@/hooks/use-feedback';
+import { usePinGuard } from '@/hooks/use-pin-guard';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { ToastAction } from '@/components/ui/toast';
@@ -9,6 +10,7 @@ import { useToast } from '@/hooks/use-toast';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import PayoutDialog from '@/components/PayoutDialog';
 import AddChoreDialog from '@/components/AddChoreDialog';
+import PinPromptDialog from '@/components/PinPromptDialog';
 import { formatValue } from '@/lib/format';
 import { ArrowLeft, Check, DollarSign, Edit, Trash2, Plus, Star } from 'lucide-react';
 import { Chore } from '@shared/schema';
@@ -33,6 +35,7 @@ export default function ChildChoresPage({ childId }: ChildChoresPageProps) {
   const toggleFavorite = useToggleFavoriteChore(childId);
   const { choreFeedback } = useFeedback();
   const { toast } = useToast();
+  const pinGate = usePinGuard();
 
   // Reset UI state when childId changes (navigating between children)
   useEffect(() => {
@@ -261,7 +264,7 @@ export default function ChildChoresPage({ childId }: ChildChoresPageProps) {
                       <Star className={`w-4 h-4 ${isFavorite ? 'fill-current' : ''}`} />
                     </Button>
                   <Button
-                    onClick={() => handleEditChore(chore)}
+                    onClick={() => pinGate.guard(() => handleEditChore(chore))}
                     variant="outline"
                     size="sm"
                     className="p-2 hover:bg-brand-grayLight"
@@ -271,7 +274,7 @@ export default function ChildChoresPage({ childId }: ChildChoresPageProps) {
                     <Edit className="w-4 h-4" />
                   </Button>
                   <Button
-                    onClick={() => handleDeleteChore(chore.id, chore.title)}
+                    onClick={() => pinGate.guard(() => handleDeleteChore(chore.id, chore.title))}
                     variant="outline"
                     size="sm"
                     className="p-2 hover:bg-red-50 hover:border-red-300 hover:text-red-600"
@@ -335,7 +338,7 @@ export default function ChildChoresPage({ childId }: ChildChoresPageProps) {
                   {formatValueDisplay(child.totalCents)}
                 </div>
                 <Button
-                  onClick={() => setShowPayoutDialog(true)}
+                  onClick={() => pinGate.guard(() => setShowPayoutDialog(true))}
                   className="bg-white text-brand-coral px-6 py-2 rounded-xl font-medium mt-2 hover:bg-white/90"
                   data-testid="button-payout"
                 >
@@ -354,11 +357,13 @@ export default function ChildChoresPage({ childId }: ChildChoresPageProps) {
         child={child}
       />
 
-      <AddChoreDialog 
-        open={showAddChore} 
+      <AddChoreDialog
+        open={showAddChore}
         onOpenChange={setShowAddChore}
         existingChore={editingChore}
       />
+
+      <PinPromptDialog {...pinGate.pinPromptProps} />
     </div>
   );
 }

--- a/client/src/pages/ChildChoresPage.tsx
+++ b/client/src/pages/ChildChoresPage.tsx
@@ -66,7 +66,7 @@ export default function ChildChoresPage({ childId }: ChildChoresPageProps) {
     if (!child) return;
 
     try {
-      await completeChore.mutateAsync({ childId: child.id, choreValueCents });
+      await completeChore.mutateAsync({ childId: child.id, choreId, choreTitle, choreValueCents });
       await choreFeedback();
 
       toast({

--- a/client/src/pages/ChoresPage.tsx
+++ b/client/src/pages/ChoresPage.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
 import { useChores, useDeleteChore } from '@/hooks/use-app-data';
+import { usePinGuard } from '@/hooks/use-pin-guard';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import AddChoreDialog from '@/components/AddChoreDialog';
+import PinPromptDialog from '@/components/PinPromptDialog';
 import { formatValue } from '@/lib/format';
 import { Chore } from '@shared/schema';
 import { Plus, Edit, Trash2, ListTodo } from 'lucide-react';
@@ -18,6 +20,7 @@ export default function ChoresPage() {
   const { data: settings } = useSettings();
   const deleteChore = useDeleteChore();
   const { toast } = useToast();
+  const pinGate = usePinGuard();
 
   const formatValueDisplay = (cents: number) => {
     return formatValue(cents, settings?.displayMode);
@@ -105,7 +108,7 @@ export default function ChoresPage() {
                   <Button
                     size="sm"
                     variant="ghost"
-                    onClick={() => handleEditChore(chore)}
+                    onClick={() => pinGate.guard(() => handleEditChore(chore))}
                     className="text-brand-grayDark/60 hover:text-brand-grayDark hover:bg-brand-grayLight"
                     data-testid={`button-edit-chore-${chore.id}`}
                   >
@@ -114,7 +117,7 @@ export default function ChoresPage() {
                   <Button
                     size="sm"
                     variant="ghost"
-                    onClick={() => handleDeleteChore(chore.id, chore.title)}
+                    onClick={() => pinGate.guard(() => handleDeleteChore(chore.id, chore.title))}
                     className="text-brand-coral/60 hover:text-brand-coral hover:bg-brand-coral/10"
                     data-testid={`button-delete-chore-${chore.id}`}
                   >
@@ -130,11 +133,13 @@ export default function ChoresPage() {
         </CardContent>
       </Card>
 
-      <AddChoreDialog 
-        open={showAddChore} 
+      <AddChoreDialog
+        open={showAddChore}
         onOpenChange={handleCloseChoreDialog}
         existingChore={editingChore}
       />
+
+      <PinPromptDialog {...pinGate.pinPromptProps} />
     </div>
   );
 }

--- a/client/src/pages/HistoryPage.tsx
+++ b/client/src/pages/HistoryPage.tsx
@@ -1,4 +1,4 @@
-import { usePayouts, useSettings } from '@/hooks/use-app-data';
+import { usePayouts, useChildren, useSettings } from '@/hooks/use-app-data';
 import { Card, CardContent } from '@/components/ui/card';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import { formatValue } from '@/lib/format';
@@ -6,8 +6,18 @@ import { CheckCircle, History } from 'lucide-react';
 import { format } from 'date-fns';
 
 export default function HistoryPage() {
-  const { data: payouts, isLoading } = usePayouts();
+  const { data: payouts, isLoading: payoutsLoading } = usePayouts();
+  // Payouts no longer carry a childName snapshot (see shared/schema.ts):
+  // the display name is resolved here by joining on childId. A payout
+  // whose child no longer exists can't occur in practice, since
+  // AppStorage.deleteChild cascades a child's payouts, but "Unknown" is
+  // kept as a defensive fallback for odd/legacy imported data.
+  const { data: children, isLoading: childrenLoading } = useChildren();
   const { data: settings } = useSettings();
+  const isLoading = payoutsLoading || childrenLoading;
+
+  const childNameById = new Map((children || []).map((child) => [child.id, child.name]));
+  const getPayoutChildName = (childId: string) => childNameById.get(childId) ?? 'Unknown';
 
   const formatValueDisplay = (cents: number) => {
     return formatValue(cents, settings?.displayMode);
@@ -56,19 +66,21 @@ export default function HistoryPage() {
 
       {/* Payout History List */}
       <div className="space-y-4">
-        {payouts?.map((payout, index) => (
+        {payouts?.map((payout, index) => {
+          const payoutChildName = getPayoutChildName(payout.childId);
+          return (
           <Card key={payout.id} className="shadow-soft" data-testid={`card-payout-${payout.id}`}>
             <CardContent className="p-4">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3">
                   <div className={`w-10 h-10 bg-gradient-to-br ${getGradientClass(index)} rounded-lg flex items-center justify-center`}>
                     <span className="text-white font-bold text-sm" data-testid={`text-payout-initials-${payout.id}`}>
-                      {getChildInitials(payout.childName)}
+                      {getChildInitials(payoutChildName)}
                     </span>
                   </div>
                   <div>
                     <h3 className="font-medium text-brand-grayDark" data-testid={`text-payout-child-${payout.id}`}>
-                      {payout.childName}
+                      {payoutChildName}
                     </h3>
                     <p className="text-brand-grayDark/60 text-sm" data-testid={`text-payout-date-${payout.id}`}>
                       {formatDate(payout.createdAt)}
@@ -87,7 +99,8 @@ export default function HistoryPage() {
               </div>
             </CardContent>
           </Card>
-        ))}
+          );
+        })}
       </div>
 
       {/* Empty State */}

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useChildren, useChores, usePayouts, useSettings } from '@/hooks/use-app-data';
+import { useChildren, useChores, usePayouts, useCompletions, useSettings } from '@/hooks/use-app-data';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import LoadingSpinner from '@/components/LoadingSpinner';
@@ -14,9 +14,10 @@ export default function HomePage() {
   const { data: children, isLoading: childrenLoading } = useChildren();
   const { data: chores, isLoading: choresLoading } = useChores();
   const { data: payouts, isLoading: payoutsLoading } = usePayouts();
+  const { data: completions, isLoading: completionsLoading } = useCompletions();
   const { data: settings } = useSettings();
 
-  const isLoading = childrenLoading || choresLoading || payoutsLoading;
+  const isLoading = childrenLoading || choresLoading || payoutsLoading || completionsLoading;
 
   const formatValueDisplay = (cents: number) => {
     return formatValue(cents, settings?.displayMode);
@@ -76,6 +77,9 @@ export default function HomePage() {
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {children?.map((child, index) => {
           const progressPercent = Math.min((child.totalCents / 1000) * 100, 100); // Progress to $10
+          // Real derived count from the completions ledger, not an estimate
+          // off totalCents (see issue #34: not every chore is worth $1).
+          const childDoneCount = completions?.filter(c => c.childId === child.id).length || 0;
 
           return (
             <Link key={child.id} href={`/child/${child.id}`}>
@@ -112,7 +116,7 @@ export default function HomePage() {
                           />
                         </div>
                         <span className="text-xs text-brand-grayDark/60" data-testid={`text-child-progress-${child.id}`}>
-                          toward $10 goal
+                          {childDoneCount} done · toward $10 goal
                         </span>
                       </div>
                     </div>

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -1,29 +1,54 @@
 import { useState } from 'react';
-import { useChildren, useSettings, useDeleteChild, useUpdateSettings, useExportData, useImportData } from '@/hooks/use-app-data';
+import { useChildren, useChores, usePayouts, useSettings, useDeleteChild, useUpdateSettings, useExportData, useImportData } from '@/hooks/use-app-data';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@/components/ui/alert-dialog';
 import { useToast } from '@/hooks/use-toast';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import AddChildDialog from '@/components/AddChildDialog';
-import { Settings, appDataSchema } from '@shared/schema';
+import { Settings, appDataSchema, AppData } from '@shared/schema';
 import { formatValue } from '@/lib/format';
+import { describeImportScope, isDataEmpty, ImportScopeCounts } from '@/lib/import-scope';
 import { Plus, Edit2, Trash2, Download, Upload, Users } from 'lucide-react';
 
 // Shared with App.tsx's backup reminder check.
 export const LAST_EXPORT_STORAGE_KEY = 'chores-rewards-last-export';
 
+interface PendingImport {
+  data: AppData;
+  // Snapshot of what's about to be replaced, taken at the moment the file
+  // was picked, so the dialog names exactly what it's asking the user to
+  // confirm even if the underlying queries refetch in the background.
+  scope: ImportScopeCounts;
+}
+
 export default function SettingsPage() {
   const [showAddChild, setShowAddChild] = useState(false);
-  
+  // An import ready to run, once the user confirms it will replace what's
+  // currently in the database. Null when there's nothing pending, which
+  // also doubles as the AlertDialog's open/closed state.
+  const [pendingImport, setPendingImport] = useState<PendingImport | null>(null);
+
   const { data: children, isLoading: childrenLoading } = useChildren();
+  const { data: chores } = useChores();
+  const { data: payouts } = usePayouts();
   const { data: settings, isLoading: settingsLoading } = useSettings();
-  
+
   const deleteChild = useDeleteChild();
   const updateSettings = useUpdateSettings();
   const exportData = useExportData();
   const importData = useImportData();
-  
+
   const { toast } = useToast();
 
   const isLoading = childrenLoading || settingsLoading;
@@ -81,21 +106,27 @@ export default function SettingsPage() {
     }
   };
 
+  // Downloads the current database contents as a backup file. Used both by
+  // the explicit "Export Backup" button and, unlabelled by its own toast, as
+  // the automatic pre-import safety net (see handleConfirmImport).
+  const downloadBackup = async (): Promise<void> => {
+    const data = await exportData.mutateAsync();
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `chores-backup-${new Date().toISOString().split('T')[0]}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+
+    localStorage.setItem(LAST_EXPORT_STORAGE_KEY, String(Date.now()));
+  };
+
   const handleExport = async () => {
     try {
-      const data = await exportData.mutateAsync();
-      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `chores-backup-${new Date().toISOString().split('T')[0]}.json`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-
-      localStorage.setItem(LAST_EXPORT_STORAGE_KEY, String(Date.now()));
-
+      await downloadBackup();
       toast({
         title: "Export Complete",
         description: "Your data has been exported successfully",
@@ -109,11 +140,27 @@ export default function SettingsPage() {
     }
   };
 
+  const runImport = async (data: AppData) => {
+    try {
+      await importData.mutateAsync(data);
+      toast({
+        title: "Import Complete",
+        description: "Your data has been imported successfully",
+      });
+    } catch (error) {
+      toast({
+        title: "Error",
+        description: "Failed to import data. Please check the file format.",
+        variant: "destructive",
+      });
+    }
+  };
+
   const handleImport = async () => {
     const input = document.createElement('input');
     input.type = 'file';
     input.accept = '.json';
-    
+
     input.onchange = async (e) => {
       const file = (e.target as HTMLInputElement).files?.[0];
       if (!file) return;
@@ -141,25 +188,48 @@ export default function SettingsPage() {
         return;
       }
 
-      try {
-        await importData.mutateAsync(result.data);
+      // Importing is destructive: it replaces every child, chore and payout
+      // wholesale (see AppStorage.importData). When there's existing data to
+      // lose, name the scope and hold off writing anything to the database
+      // until the user confirms via the AlertDialog below - which itself
+      // triggers an automatic backup download of what's about to be
+      // replaced before the import proceeds. A genuinely empty database has
+      // nothing to confirm or back up, so that case imports immediately.
+      const currentCounts = {
+        children: children?.length ?? 0,
+        chores: chores?.length ?? 0,
+        payouts: payouts?.length ?? 0,
+      };
 
-        toast({
-          title: "Import Complete",
-          description: "Your data has been imported successfully",
-        });
-      } catch (error) {
-        toast({
-          title: "Error",
-          description: "Failed to import data. Please check the file format.",
-          variant: "destructive",
-        });
+      if (isDataEmpty(currentCounts)) {
+        await runImport(result.data);
+        return;
       }
+
+      setPendingImport({ data: result.data, scope: currentCounts });
     };
-    
+
     input.click();
   };
 
+  const handleConfirmImport = async () => {
+    if (!pendingImport) return;
+    const { data } = pendingImport;
+    setPendingImport(null);
+
+    try {
+      await downloadBackup();
+    } catch (error) {
+      toast({
+        title: "Error",
+        description: "Couldn't back up your current data, so the import was cancelled",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    await runImport(data);
+  };
 
   if (isLoading) {
     return <LoadingSpinner className="min-h-[50vh]" />;
@@ -315,6 +385,30 @@ export default function SettingsPage() {
       </Card>
 
       <AddChildDialog open={showAddChild} onOpenChange={setShowAddChild} />
+
+      <AlertDialog open={!!pendingImport} onOpenChange={(open) => { if (!open) setPendingImport(null); }}>
+        <AlertDialogContent data-testid="dialog-confirm-import">
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {pendingImport && describeImportScope(pendingImport.scope)}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              This import replaces your current data completely. We'll download a backup of what's
+              currently stored first, in case you need to undo this.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel data-testid="button-cancel-import">Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmImport}
+              className="bg-brand-coral hover:bg-brand-coral/90"
+              data-testid="button-confirm-import"
+            >
+              Back Up &amp; Replace
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useChildren, useChores, usePayouts, useSettings, useDeleteChild, useUpdateSettings, useExportData, useImportData } from '@/hooks/use-app-data';
+import { usePinGuard } from '@/hooks/use-pin-guard';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
@@ -16,10 +17,12 @@ import {
 import { useToast } from '@/hooks/use-toast';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import AddChildDialog from '@/components/AddChildDialog';
+import PinPromptDialog from '@/components/PinPromptDialog';
+import PinSetupDialog from '@/components/PinSetupDialog';
 import { Settings, appDataSchema, AppData } from '@shared/schema';
 import { formatValue } from '@/lib/format';
 import { describeImportScope, isDataEmpty, ImportScopeCounts } from '@/lib/import-scope';
-import { Plus, Edit2, Trash2, Download, Upload, Users } from 'lucide-react';
+import { Plus, Edit2, Trash2, Download, Upload, Users, Lock } from 'lucide-react';
 
 // Shared with App.tsx's backup reminder check.
 export const LAST_EXPORT_STORAGE_KEY = 'chores-rewards-last-export';
@@ -38,6 +41,8 @@ export default function SettingsPage() {
   // currently in the database. Null when there's nothing pending, which
   // also doubles as the AlertDialog's open/closed state.
   const [pendingImport, setPendingImport] = useState<PendingImport | null>(null);
+  const [showPinSetup, setShowPinSetup] = useState(false);
+  const pinGate = usePinGuard();
 
   const { data: children, isLoading: childrenLoading } = useChildren();
   const { data: chores } = useChores();
@@ -280,7 +285,7 @@ export default function SettingsPage() {
                   <Button
                     size="sm"
                     variant="ghost"
-                    onClick={() => handleDeleteChild(child.id, child.name)}
+                    onClick={() => pinGate.guard(() => handleDeleteChild(child.id, child.name))}
                     className="text-brand-coral/60 hover:text-brand-coral hover:bg-brand-coral/10"
                     aria-label={`Delete ${child.name}`}
                     data-testid={`button-delete-child-${child.id}`}
@@ -354,6 +359,29 @@ export default function SettingsPage() {
         </CardContent>
       </Card>
 
+      {/* Parent PIN */}
+      <Card className="shadow-soft">
+        <CardContent className="p-6">
+          <div className="flex items-center gap-2 mb-1">
+            <Lock className="w-5 h-5 text-brand-coral" />
+            <h2 className="text-xl font-semibold text-brand-grayDark">Parent PIN</h2>
+          </div>
+          <p className="text-brand-grayDark/60 text-sm mb-4">
+            {settings?.pinHash
+              ? 'A PIN currently guards paying out, editing or deleting a chore, deleting a child and importing a backup.'
+              : 'Set an optional 4-6 digit PIN to guard paying out, editing or deleting a chore, deleting a child and importing a backup. Adding and completing chores always stay open to kids.'}
+          </p>
+          <Button
+            onClick={() => setShowPinSetup(true)}
+            size="sm"
+            className="bg-brand-teal hover:bg-brand-teal/90 shadow-soft"
+            data-testid="button-manage-pin"
+          >
+            {settings?.pinHash ? 'Change or Remove PIN' : 'Set Parent PIN'}
+          </Button>
+        </CardContent>
+      </Card>
+
       {/* Data Management */}
       <Card className="shadow-soft">
         <CardContent className="p-6">
@@ -369,7 +397,7 @@ export default function SettingsPage() {
               {exportData.isPending ? 'Exporting...' : 'Export Backup'}
             </Button>
             <Button
-              onClick={handleImport}
+              onClick={() => pinGate.guard(handleImport)}
               disabled={importData.isPending}
               className="bg-brand-yellow hover:bg-brand-yellow/90 text-brand-yellow-dark shadow-soft"
               data-testid="button-import-data"
@@ -409,6 +437,9 @@ export default function SettingsPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <PinSetupDialog open={showPinSetup} onOpenChange={setShowPinSetup} />
+      <PinPromptDialog {...pinGate.pinPromptProps} />
     </div>
   );
 }

--- a/client/src/pages/TotalsPage.tsx
+++ b/client/src/pages/TotalsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useChildren, usePayouts, useSettings } from '@/hooks/use-app-data';
+import { useChildren, useCompletions, useSettings } from '@/hooks/use-app-data';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import LoadingSpinner from '@/components/LoadingSpinner';
@@ -11,12 +11,12 @@ import { DollarSign, Users } from 'lucide-react';
 export default function TotalsPage() {
   const [showPayoutDialog, setShowPayoutDialog] = useState(false);
   const [selectedChild, setSelectedChild] = useState<Child | null>(null);
-  
+
   const { data: children, isLoading: childrenLoading } = useChildren();
-  const { data: payouts, isLoading: payoutsLoading } = usePayouts();
+  const { data: completions, isLoading: completionsLoading } = useCompletions();
   const { data: settings } = useSettings();
 
-  const isLoading = childrenLoading || payoutsLoading;
+  const isLoading = childrenLoading || completionsLoading;
 
   const formatValueDisplay = (cents: number) => {
     return formatValue(cents, settings?.displayMode);
@@ -73,7 +73,9 @@ export default function TotalsPage() {
       {/* Individual Child Totals */}
       <div className="space-y-4">
         {children?.map((child, index) => {
-          const childPayouts = payouts?.filter(p => p.childId === child.id) || [];
+          // Real derived count from the completions ledger, not an estimate
+          // off totalCents (see issue #34: not every chore is worth $1).
+          const childCompletedCount = completions?.filter(c => c.childId === child.id).length || 0;
 
           return (
             <Card key={child.id} className="shadow-soft" data-testid={`card-child-total-${child.id}`}>
@@ -90,7 +92,7 @@ export default function TotalsPage() {
                         {child.name}
                       </h3>
                       <p className="text-brand-grayDark/60 text-sm" data-testid={`text-child-chores-${child.id}`}>
-                        {childPayouts.length} total payouts
+                        {childCompletedCount} {childCompletedCount === 1 ? 'chore' : 'chores'} completed
                       </p>
                     </div>
                   </div>

--- a/client/src/pages/TotalsPage.tsx
+++ b/client/src/pages/TotalsPage.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 import { useChildren, useCompletions, useSettings } from '@/hooks/use-app-data';
+import { usePinGuard } from '@/hooks/use-pin-guard';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import PayoutDialog from '@/components/PayoutDialog';
+import PinPromptDialog from '@/components/PinPromptDialog';
 import { Child } from '@shared/schema';
 import { formatValue } from '@/lib/format';
 import { DollarSign, Users } from 'lucide-react';
@@ -15,6 +17,7 @@ export default function TotalsPage() {
   const { data: children, isLoading: childrenLoading } = useChildren();
   const { data: completions, isLoading: completionsLoading } = useCompletions();
   const { data: settings } = useSettings();
+  const pinGate = usePinGuard();
 
   const isLoading = childrenLoading || completionsLoading;
 
@@ -37,8 +40,10 @@ export default function TotalsPage() {
   };
 
   const handlePayoutClick = (child: Child) => {
-    setSelectedChild(child);
-    setShowPayoutDialog(true);
+    pinGate.guard(() => {
+      setSelectedChild(child);
+      setShowPayoutDialog(true);
+    });
   };
 
   const globalTotal = children?.reduce((sum, child) => sum + child.totalCents, 0) || 0;
@@ -131,11 +136,13 @@ export default function TotalsPage() {
         </Card>
       )}
 
-      <PayoutDialog 
-        open={showPayoutDialog} 
+      <PayoutDialog
+        open={showPayoutDialog}
         onOpenChange={setShowPayoutDialog}
         child={selectedChild}
       />
+
+      <PinPromptDialog {...pinGate.pinPromptProps} />
     </div>
   );
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -78,6 +78,12 @@ export const settingsSchema = z.object({
   haptics: z.boolean().default(true),
   confetti: z.boolean().default(true),
   displayMode: z.enum(['dollars', 'points']).default('dollars'),
+  // Optional parent PIN, stored only as a salted SHA-256 hash (see
+  // client/src/lib/pin.ts) - never the PIN itself. Both fields are present
+  // together or absent together; undefined means no PIN is set and every
+  // gated action behaves exactly as if PINs didn't exist.
+  pinHash: z.string().optional(),
+  pinSalt: z.string().optional(),
 });
 
 export type Settings = z.infer<typeof settingsSchema>;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -35,18 +35,39 @@ export const insertChoreSchema = choreSchema.omit({
 export type Chore = z.infer<typeof choreSchema>;
 export type InsertChore = z.infer<typeof insertChoreSchema>;
 
+// Completion schema
+// Records an individual chore completion so real "N done" counts can be
+// derived instead of estimated from totalCents. choreTitle is a snapshot
+// taken at completion time (not a join on choreId) because chores are
+// deletable and the completion should still read sensibly afterwards.
+export const completionSchema = z.object({
+  id: z.string(),
+  childId: z.string(),
+  choreId: z.string(),
+  choreTitle: z.string(),
+  valueCents: z.number().int().min(0),
+  createdAt: z.coerce.date(),
+});
+
+export type Completion = z.infer<typeof completionSchema>;
+
 // Payout history schema
+// Deliberately has no childName snapshot: AppStorage.deleteChild cascades a
+// child's payouts when the child is deleted, so a payout can never outlive
+// its child and the name is always resolved by joining on childId at
+// display time (see HistoryPage). Old backups that still carry childName
+// parse fine, since zod strips unknown keys by default; the field just
+// never gets read or written again.
 export const payoutSchema = z.object({
   id: z.string(),
   childId: z.string(),
-  childName: z.string(),
   amountCents: z.number().int().min(0),
   createdAt: z.coerce.date(),
 });
 
-export const insertPayoutSchema = payoutSchema.omit({ 
-  id: true, 
-  createdAt: true 
+export const insertPayoutSchema = payoutSchema.omit({
+  id: true,
+  createdAt: true
 });
 
 export type Payout = z.infer<typeof payoutSchema>;
@@ -66,6 +87,9 @@ export const appDataSchema = z.object({
   children: z.array(childSchema),
   chores: z.array(choreSchema),
   payouts: z.array(payoutSchema),
+  // Defaults to [] so a legacy backup taken before completions existed
+  // still imports cleanly instead of failing validation.
+  completions: z.array(completionSchema).default([]),
   settings: settingsSchema,
   exportedAt: z.coerce.date(),
 });

--- a/tests/e2e/journey.spec.ts
+++ b/tests/e2e/journey.spec.ts
@@ -65,3 +65,44 @@ test('add a child, complete a chore, pay out, and see it in history', async ({ p
     `$${(choreValueCents / 100).toFixed(2)}`,
   );
 });
+
+// The happy path above deliberately never sets a PIN, so it also proves the
+// "no PIN set = ungated" default (Pay Out works with no prompt at all).
+// This second journey covers the gated side: once a PIN is set, Pay Out is
+// blocked behind PinPromptDialog until the correct PIN is entered.
+test('setting a parent PIN gates Pay Out until the PIN is entered', async ({ page }) => {
+  await page.goto('/');
+
+  const childName = `Test Child ${Date.now()}`;
+  await page.getByTestId('input-first-child-name').fill(childName);
+  await page.getByTestId('button-add-first-child').click();
+
+  await expect(page.getByTestId('nav-home')).toBeVisible();
+
+  // Set a parent PIN from Settings.
+  await page.getByTestId('nav-settings').click();
+  await page.getByTestId('button-manage-pin').click();
+  await page.getByTestId('input-pin-new').fill('1234');
+  await page.getByTestId('input-pin-confirm').fill('1234');
+  await page.getByTestId('button-save-pin').click();
+  await expect(page.getByTestId('button-manage-pin')).toHaveText('Change or Remove PIN');
+
+  // Complete a chore (left open to kids - no PIN prompt expected) then try
+  // to pay out, which is gated.
+  await page.getByTestId('nav-home').click();
+  await page.locator('[data-testid^="button-view-chores-"]').click();
+  await page.locator('[data-testid^="button-complete-chore-"]').first().click();
+
+  await page.getByTestId('button-payout').click();
+  await expect(page.getByTestId('input-pin-prompt')).toBeVisible();
+
+  // Wrong PIN is rejected with an inline error, not silently let through.
+  await page.getByTestId('input-pin-prompt').fill('9999');
+  await page.getByTestId('button-confirm-pin-prompt').click();
+  await expect(page.getByTestId('text-pin-prompt-error')).toBeVisible();
+
+  // The correct PIN lets the payout dialog through.
+  await page.getByTestId('input-pin-prompt').fill('1234');
+  await page.getByTestId('button-confirm-pin-prompt').click();
+  await expect(page.getByTestId('button-confirm-payout')).toBeVisible();
+});

--- a/tests/unit/db-migration.test.ts
+++ b/tests/unit/db-migration.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest';
+import { IDBFactory } from 'fake-indexeddb';
+
+// Verifies the v2 -> v3 upgrade in client/src/lib/db.ts: a database that
+// already has the pre-completions schema (children/chores/payouts/settings,
+// seeded with real data, no completions store) must come through the
+// upgrade with that data intact and gain a usable completions store - not
+// just a store that exists, but one that can actually be read from and
+// written to afterwards.
+describe('IndexedDB v2 -> v3 migration', () => {
+  it('preserves existing children/chores/payouts/settings data and adds a working completions store', async () => {
+    // Fresh, empty backing store for this test, independent of any other
+    // test's database.
+    globalThis.indexedDB = new IDBFactory();
+
+    const now = new Date('2026-01-01T00:00:00.000Z');
+
+    // Open the database directly at version 2, matching the schema this
+    // app shipped before completions existed. This is built with raw
+    // indexedDB calls, not via client/src/lib/db.ts, so it is a genuine
+    // "existing installation" fixture rather than something that already
+    // knows about v3.
+    await new Promise<void>((resolve, reject) => {
+      const openRequest = indexedDB.open('chores-rewards-db', 2);
+
+      openRequest.onupgradeneeded = () => {
+        const db = openRequest.result;
+        db.createObjectStore('children', { keyPath: 'id' });
+        db.createObjectStore('chores', { keyPath: 'id' });
+        db.createObjectStore('payouts', { keyPath: 'id' });
+        db.createObjectStore('settings');
+      };
+
+      openRequest.onsuccess = () => {
+        const db = openRequest.result;
+        const tx = db.transaction(['children', 'chores', 'payouts', 'settings'], 'readwrite');
+
+        tx.objectStore('children').add({
+          id: 'c1', name: 'Aria', totalCents: 500, favoriteChoreIds: [], createdAt: now,
+        });
+        tx.objectStore('chores').add({
+          id: 'ch1', title: 'Vacuum', valueCents: 500, createdAt: now,
+        });
+        tx.objectStore('payouts').add({
+          id: 'p1', childId: 'c1', childName: 'Aria', amountCents: 200, createdAt: now,
+        });
+        tx.objectStore('settings').put({ haptics: true, confetti: true, displayMode: 'dollars' }, 'app-settings');
+
+        tx.oncomplete = () => {
+          db.close();
+          resolve();
+        };
+        tx.onerror = () => reject(tx.error);
+      };
+
+      openRequest.onerror = () => reject(openRequest.error);
+    });
+
+    // Now open it through our own module, which upgrades v2 databases to
+    // v3 (see client/src/lib/db.ts). resetModules so db.ts's module-level
+    // dbInstance/dbPromise caches don't carry over from another test.
+    vi.resetModules();
+    const { getDB } = await import('@/lib/db');
+    const { storage } = await import('@/lib/storage');
+
+    const db = await getDB();
+    expect(db.objectStoreNames.contains('completions')).toBe(true);
+
+    // Pre-existing data in every store survived the upgrade untouched.
+    const children = await storage.getAllChildren();
+    expect(children).toHaveLength(1);
+    expect(children[0].id).toBe('c1');
+    expect(children[0].totalCents).toBe(500);
+
+    const chores = await storage.getAllChores();
+    expect(chores).toHaveLength(1);
+    expect(chores[0].id).toBe('ch1');
+
+    const payouts = await storage.getAllPayouts();
+    expect(payouts).toHaveLength(1);
+    expect(payouts[0].id).toBe('p1');
+
+    const settings = await storage.getSettings();
+    expect(settings.displayMode).toBe('dollars');
+
+    // The new store exists and starts empty...
+    const completionsBefore = await storage.getAllCompletions();
+    expect(completionsBefore).toEqual([]);
+
+    // ...and is actually usable, not just present: a completion recorded
+    // after the upgrade is readable back, and the pre-existing balance
+    // still accumulates correctly on top of it.
+    const { child: updatedChild, completion } = await storage.completeChore('c1', 'ch1', 'Vacuum', 500);
+    expect(updatedChild.totalCents).toBe(1000);
+    expect(completion.choreTitle).toBe('Vacuum');
+
+    const completionsAfter = await storage.getAllCompletions();
+    expect(completionsAfter).toHaveLength(1);
+    expect(completionsAfter[0].id).toBe(completion.id);
+  });
+});

--- a/tests/unit/import-scope.test.ts
+++ b/tests/unit/import-scope.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { describeImportScope, isDataEmpty } from '@/lib/import-scope';
+
+describe('isDataEmpty', () => {
+  it('is true only when children, chores and payouts are all zero', () => {
+    expect(isDataEmpty({ children: 0, chores: 0, payouts: 0 })).toBe(true);
+  });
+
+  it('is false when any one count is non-zero', () => {
+    expect(isDataEmpty({ children: 1, chores: 0, payouts: 0 })).toBe(false);
+    expect(isDataEmpty({ children: 0, chores: 1, payouts: 0 })).toBe(false);
+    expect(isDataEmpty({ children: 0, chores: 0, payouts: 1 })).toBe(false);
+  });
+});
+
+describe('describeImportScope', () => {
+  it('names the exact scope with correct pluralisation', () => {
+    expect(describeImportScope({ children: 2, chores: 24, payouts: 15 })).toBe(
+      'Replace 2 children, 24 chores and 15 payouts?',
+    );
+  });
+
+  it('uses singular nouns for a count of exactly one', () => {
+    expect(describeImportScope({ children: 1, chores: 1, payouts: 1 })).toBe(
+      'Replace 1 child, 1 chore and 1 payout?',
+    );
+  });
+
+  it('still produces a sensible sentence for an all-zero scope', () => {
+    expect(describeImportScope({ children: 0, chores: 0, payouts: 0 })).toBe(
+      'Replace 0 children, 0 chores and 0 payouts?',
+    );
+  });
+});

--- a/tests/unit/pin.test.ts
+++ b/tests/unit/pin.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  generateSalt,
+  hashPin,
+  verifyPin,
+  markPinVerified,
+  isPinGraceActive,
+  resetPinGraceForTests,
+} from '@/lib/pin';
+
+describe('hashPin / verifyPin', () => {
+  it('verifies a correct PIN against its own hash and salt', async () => {
+    const salt = generateSalt();
+    const hash = await hashPin('1234', salt);
+
+    expect(await verifyPin('1234', salt, hash)).toBe(true);
+  });
+
+  it('rejects an incorrect PIN against the same hash and salt', async () => {
+    const salt = generateSalt();
+    const hash = await hashPin('1234', salt);
+
+    expect(await verifyPin('9999', salt, hash)).toBe(false);
+  });
+
+  it('never stores the PIN itself: the hash does not contain the raw digits', async () => {
+    const salt = generateSalt();
+    const hash = await hashPin('1234', salt);
+
+    expect(hash).not.toContain('1234');
+  });
+
+  it('produces different hashes for the same PIN under different salts', async () => {
+    const hashA = await hashPin('1234', generateSalt());
+    const hashB = await hashPin('1234', generateSalt());
+
+    expect(hashA).not.toBe(hashB);
+  });
+
+  it('generates a fresh salt on every call', () => {
+    expect(generateSalt()).not.toBe(generateSalt());
+  });
+});
+
+describe('PIN grace window', () => {
+  beforeEach(() => {
+    resetPinGraceForTests();
+    vi.useRealTimers();
+  });
+
+  it('is not active before any verification', () => {
+    expect(isPinGraceActive()).toBe(false);
+  });
+
+  it('is active immediately after a successful verification', () => {
+    markPinVerified();
+    expect(isPinGraceActive()).toBe(true);
+  });
+
+  it('expires after the grace window elapses', () => {
+    vi.useFakeTimers();
+    try {
+      markPinVerified();
+      expect(isPinGraceActive()).toBe(true);
+
+      vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+      expect(isPinGraceActive()).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/unit/schema.test.ts
+++ b/tests/unit/schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { appDataSchema, bugReportSchema } from '@shared/schema';
+import { appDataSchema, bugReportSchema, payoutSchema, settingsSchema } from '@shared/schema';
 
 describe('appDataSchema', () => {
   const validPayload = {
@@ -8,7 +8,10 @@ describe('appDataSchema', () => {
     ],
     chores: [{ id: 'ch1', title: 'Vacuum', valueCents: 500, createdAt: '2026-01-01T00:00:00.000Z' }],
     payouts: [
-      { id: 'p1', childId: 'c1', childName: 'Aria', amountCents: 100, createdAt: '2026-01-01T00:00:00.000Z' },
+      { id: 'p1', childId: 'c1', amountCents: 100, createdAt: '2026-01-01T00:00:00.000Z' },
+    ],
+    completions: [
+      { id: 'comp1', childId: 'c1', choreId: 'ch1', choreTitle: 'Vacuum', valueCents: 500, createdAt: '2026-01-01T00:00:00.000Z' },
     ],
     settings: { haptics: true, confetti: true, displayMode: 'dollars' },
     exportedAt: '2026-01-02T00:00:00.000Z',
@@ -20,6 +23,7 @@ describe('appDataSchema', () => {
     expect(result.children[0].createdAt).toBeInstanceOf(Date);
     expect(result.chores[0].createdAt).toBeInstanceOf(Date);
     expect(result.payouts[0].createdAt).toBeInstanceOf(Date);
+    expect(result.completions[0].createdAt).toBeInstanceOf(Date);
     expect(result.exportedAt).toBeInstanceOf(Date);
     expect(result.exportedAt.toISOString()).toBe('2026-01-02T00:00:00.000Z');
   });
@@ -39,6 +43,49 @@ describe('appDataSchema', () => {
     const { settings, ...withoutSettings } = validPayload;
     const result = appDataSchema.safeParse(withoutSettings);
     expect(result.success).toBe(false);
+  });
+
+  it('defaults completions to [] when the field is absent, so a pre-completions backup still imports', () => {
+    const { completions, ...withoutCompletions } = validPayload;
+    const result = appDataSchema.parse(withoutCompletions);
+    expect(result.completions).toEqual([]);
+  });
+});
+
+describe('payoutSchema', () => {
+  it('strips an unknown childName field instead of rejecting the record, so old backups still parse', () => {
+    const legacyPayout = {
+      id: 'p1',
+      childId: 'c1',
+      childName: 'Aria',
+      amountCents: 100,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    };
+
+    const result = payoutSchema.parse(legacyPayout);
+    expect(result).not.toHaveProperty('childName');
+    expect(result.childId).toBe('c1');
+    expect(result.amountCents).toBe(100);
+  });
+});
+
+describe('settingsSchema', () => {
+  it('defaults to no PIN configured', () => {
+    const result = settingsSchema.parse({ haptics: true, confetti: true, displayMode: 'dollars' });
+    expect(result.pinHash).toBeUndefined();
+    expect(result.pinSalt).toBeUndefined();
+  });
+
+  it('accepts a settings object carrying a PIN hash and salt', () => {
+    const result = settingsSchema.parse({
+      haptics: true,
+      confetti: true,
+      displayMode: 'dollars',
+      pinHash: 'abc123',
+      pinSalt: 'def456',
+    });
+    expect(result.pinHash).toBe('abc123');
+    expect(result.pinSalt).toBe('def456');
   });
 });
 

--- a/tests/unit/storage.test.ts
+++ b/tests/unit/storage.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { freshStorage } from './db-helper';
+import { appDataSchema } from '@shared/schema';
 import type { AppData } from '@shared/schema';
 
 describe('AppStorage.createChild', () => {
@@ -24,35 +25,115 @@ describe('AppStorage.createChild', () => {
 });
 
 describe('AppStorage.completeChore', () => {
-  it('adds the chore value to the child balance, cumulatively', async () => {
+  it('adds the chore value to the child balance and records a completion, atomically, cumulatively', async () => {
     const storage = await freshStorage();
     const child = await storage.createChild({ name: 'Aria' });
 
-    const afterFirst = await storage.completeChore(child.id, 250);
-    expect(afterFirst.totalCents).toBe(250);
+    const first = await storage.completeChore(child.id, 'chore-1', 'Vacuum', 250);
+    expect(first.child.totalCents).toBe(250);
+    expect(first.completion.childId).toBe(child.id);
+    expect(first.completion.choreId).toBe('chore-1');
+    expect(first.completion.choreTitle).toBe('Vacuum');
+    expect(first.completion.valueCents).toBe(250);
+    expect(first.completion.id).toBeTruthy();
 
-    const afterSecond = await storage.completeChore(child.id, 100);
-    expect(afterSecond.totalCents).toBe(350);
+    const second = await storage.completeChore(child.id, 'chore-2', 'Mop', 100);
+    expect(second.child.totalCents).toBe(350);
+
+    const completions = await storage.getAllCompletions();
+    expect(completions).toHaveLength(2);
   });
 
-  it('throws for an unknown child', async () => {
+  it('throws for an unknown child, and records no completion', async () => {
     const storage = await freshStorage();
-    await expect(storage.completeChore('no-such-child', 100)).rejects.toThrow('Child not found');
+    await expect(storage.completeChore('no-such-child', 'chore-1', 'Vacuum', 100)).rejects.toThrow('Child not found');
+    expect(await storage.getAllCompletions()).toEqual([]);
+  });
+
+  it('keeps the chore title as a snapshot, independent of the chore being deleted afterwards', async () => {
+    const storage = await freshStorage();
+    const child = await storage.createChild({ name: 'Aria' });
+    const chore = await storage.createChore({ title: 'Vacuum', valueCents: 500 });
+
+    const { completion } = await storage.completeChore(child.id, chore.id, chore.title, chore.valueCents);
+    await storage.deleteChore(chore.id);
+
+    const completions = await storage.getAllCompletions();
+    expect(completions).toHaveLength(1);
+    expect(completions[0].id).toBe(completion.id);
+    expect(completions[0].choreTitle).toBe('Vacuum');
+  });
+});
+
+describe('AppStorage.undoCompletion', () => {
+  it('deletes the completion and gives back its value', async () => {
+    const storage = await freshStorage();
+    const child = await storage.createChild({ name: 'Aria' });
+    const { completion } = await storage.completeChore(child.id, 'chore-1', 'Vacuum', 500);
+
+    const updated = await storage.undoCompletion(completion.id);
+    expect(updated.totalCents).toBe(0);
+
+    const completions = await storage.getAllCompletions();
+    expect(completions).toEqual([]);
+  });
+
+  it('leaves other completions and the rest of the balance untouched', async () => {
+    const storage = await freshStorage();
+    const child = await storage.createChild({ name: 'Aria' });
+    const { completion: first } = await storage.completeChore(child.id, 'chore-1', 'Vacuum', 500);
+    await storage.completeChore(child.id, 'chore-2', 'Mop', 100);
+
+    const updated = await storage.undoCompletion(first.id);
+    expect(updated.totalCents).toBe(100);
+
+    const completions = await storage.getAllCompletions();
+    expect(completions).toHaveLength(1);
+    expect(completions[0].choreId).toBe('chore-2');
+  });
+
+  // Control for hardening rule 13 (a control must fail on the broken
+  // version): this is the exact scenario the refusal exists to catch - a
+  // payout happened after the completion, so undoing it would drive the
+  // balance negative. Verified to fail against a naive implementation that
+  // unconditionally subtracts valueCents; that inversion was reverted
+  // immediately after and does not ship.
+  it('refuses when the balance has dropped below the completion value (a payout happened since), without touching either store', async () => {
+    const storage = await freshStorage();
+    const child = await storage.createChild({ name: 'Aria' });
+    const { completion } = await storage.completeChore(child.id, 'chore-1', 'Vacuum', 500);
+    await storage.payoutChild(child.id); // balance now 0
+
+    await expect(storage.undoCompletion(completion.id)).rejects.toThrow(
+      'Cannot undo: a payout has already happened since this chore was completed',
+    );
+
+    const childAfter = await storage.getChild(child.id);
+    expect(childAfter?.totalCents).toBe(0);
+
+    const completions = await storage.getAllCompletions();
+    expect(completions).toHaveLength(1);
+    expect(completions[0].id).toBe(completion.id);
+  });
+
+  it('throws for an unknown completion', async () => {
+    const storage = await freshStorage();
+    await expect(storage.undoCompletion('no-such-completion')).rejects.toThrow('Completion not found');
   });
 });
 
 describe('AppStorage.payoutChild', () => {
-  it('creates a payout row and zeroes the balance', async () => {
+  it('creates a payout row (with no childName field) and zeroes the balance', async () => {
     const storage = await freshStorage();
     const child = await storage.createChild({ name: 'Aria' });
-    await storage.completeChore(child.id, 500);
+    await storage.completeChore(child.id, 'chore-1', 'Vacuum', 500);
 
     const { child: paidChild, payout } = await storage.payoutChild(child.id);
 
     expect(paidChild.totalCents).toBe(0);
     expect(payout.amountCents).toBe(500);
     expect(payout.childId).toBe(child.id);
-    expect(payout.childName).toBe('Aria');
+    expect(payout).not.toHaveProperty('childName');
 
     const payouts = await storage.getAllPayouts();
     expect(payouts).toHaveLength(1);
@@ -73,17 +154,17 @@ describe('AppStorage.payoutChild', () => {
 });
 
 describe('AppStorage.deleteChild', () => {
-  it('removes the child and all of their payouts, leaving other children and payouts intact', async () => {
+  it('removes the child and all of their payouts and completions, leaving other children, payouts and completions intact', async () => {
     const storage = await freshStorage();
     const child = await storage.createChild({ name: 'Aria' });
     const other = await storage.createChild({ name: 'Addie' });
 
-    await storage.completeChore(child.id, 300);
+    await storage.completeChore(child.id, 'chore-1', 'Vacuum', 300);
     await storage.payoutChild(child.id);
-    await storage.completeChore(child.id, 200);
+    await storage.completeChore(child.id, 'chore-2', 'Mop', 200);
     await storage.payoutChild(child.id);
 
-    await storage.completeChore(other.id, 100);
+    await storage.completeChore(other.id, 'chore-3', 'Dishes', 100);
     await storage.payoutChild(other.id);
 
     await storage.deleteChild(child.id);
@@ -95,6 +176,10 @@ describe('AppStorage.deleteChild', () => {
     const payouts = await storage.getAllPayouts();
     expect(payouts.some((p) => p.childId === child.id)).toBe(false);
     expect(payouts.some((p) => p.childId === other.id)).toBe(true);
+
+    const completions = await storage.getAllCompletions();
+    expect(completions.some((c) => c.childId === child.id)).toBe(false);
+    expect(completions.some((c) => c.childId === other.id)).toBe(true);
   });
 });
 
@@ -120,8 +205,29 @@ describe('AppStorage.deleteChore', () => {
   });
 });
 
-describe('AppStorage.importData', () => {
-  it('replaces children, chores and payouts wholesale with a valid backup', async () => {
+describe('AppStorage.exportData / importData round trip', () => {
+  it('carries completions through an export and re-import', async () => {
+    const storage = await freshStorage();
+    const child = await storage.createChild({ name: 'Aria' });
+    const chore = await storage.createChore({ title: 'Vacuum', valueCents: 500 });
+    await storage.completeChore(child.id, chore.id, chore.title, chore.valueCents);
+
+    const exported = await storage.exportData();
+    expect(exported.completions).toHaveLength(1);
+    expect(exported.completions[0].choreTitle).toBe('Vacuum');
+
+    // Import into a second, independent database and confirm the
+    // completion survived the round trip untouched.
+    const storage2 = await freshStorage();
+    await storage2.importData(exported);
+
+    const completions = await storage2.getAllCompletions();
+    expect(completions).toHaveLength(1);
+    expect(completions[0].choreTitle).toBe('Vacuum');
+    expect(completions[0].valueCents).toBe(500);
+  });
+
+  it('replaces children, chores, payouts and completions wholesale with a valid backup', async () => {
     const storage = await freshStorage();
     await storage.createChild({ name: 'Old Kid' });
 
@@ -131,7 +237,10 @@ describe('AppStorage.importData', () => {
       ],
       chores: [{ id: 'ch1', title: 'New Chore', valueCents: 100, createdAt: new Date() }],
       payouts: [
-        { id: 'p1', childId: 'c1', childName: 'New Kid', amountCents: 200, createdAt: new Date() },
+        { id: 'p1', childId: 'c1', amountCents: 200, createdAt: new Date() },
+      ],
+      completions: [
+        { id: 'comp1', childId: 'c1', choreId: 'ch1', choreTitle: 'New Chore', valueCents: 100, createdAt: new Date() },
       ],
       settings: { haptics: false, confetti: false, displayMode: 'points' },
       exportedAt: new Date(),
@@ -153,15 +262,51 @@ describe('AppStorage.importData', () => {
     expect(payouts).toHaveLength(1);
     expect(payouts[0].id).toBe('p1');
 
+    const completions = await storage.getAllCompletions();
+    expect(completions).toHaveLength(1);
+    expect(completions[0].id).toBe('comp1');
+
     const settings = await storage.getSettings();
     expect(settings.displayMode).toBe('points');
   });
 
+  it('imports a legacy backup with no completions field and a payout still carrying childName, dropping the unused field', async () => {
+    const storage = await freshStorage();
+
+    // This is exactly the shape a backup taken before completions and the
+    // childName removal would have: no `completions` key at all, and every
+    // payout still has `childName`.
+    const legacyBackupJson = {
+      children: [
+        { id: 'c1', name: 'Aria', totalCents: 0, favoriteChoreIds: [], createdAt: '2026-01-01T00:00:00.000Z' },
+      ],
+      chores: [],
+      payouts: [
+        { id: 'p1', childId: 'c1', childName: 'Aria', amountCents: 200, createdAt: '2026-01-01T00:00:00.000Z' },
+      ],
+      settings: { haptics: true, confetti: true, displayMode: 'dollars' },
+      exportedAt: '2026-01-02T00:00:00.000Z',
+    };
+
+    const parsed = appDataSchema.parse(legacyBackupJson);
+    expect(parsed.completions).toEqual([]);
+    expect(parsed.payouts[0]).not.toHaveProperty('childName');
+
+    await storage.importData(parsed);
+
+    const payouts = await storage.getAllPayouts();
+    expect(payouts).toHaveLength(1);
+    expect(payouts[0]).not.toHaveProperty('childName');
+
+    const completions = await storage.getAllCompletions();
+    expect(completions).toEqual([]);
+  });
+
   // This is the control for import atomicity. importData clears the
-  // children/chores/payouts stores and repopulates them inside a single
-  // IndexedDB transaction (see AppStorage.importData / withTransaction in
-  // client/src/lib/storage.ts), so a failure partway through must abort the
-  // whole transaction and leave the pre-import data untouched - not
+  // children/chores/payouts/completions stores and repopulates them inside
+  // a single IndexedDB transaction (see AppStorage.importData / withTransaction
+  // in client/src/lib/storage.ts), so a failure partway through must abort
+  // the whole transaction and leave the pre-import data untouched - not
   // "cleared, with only the records that made it in before the failure".
   //
   // The backup below has two children sharing the same id, so the second
@@ -184,6 +329,7 @@ describe('AppStorage.importData', () => {
       ],
       chores: [],
       payouts: [],
+      completions: [],
       settings: { haptics: true, confetti: true, displayMode: 'dollars' },
       exportedAt: new Date(),
     };


### PR DESCRIPTION
## Summary

Four logical commits closing four engineering-audit findings:

- **feat(data)** (`79da32b`): adds a `completions` store (childId, choreId, choreTitle snapshot, valueCents, createdAt), bumps the IndexedDB schema to v3 with a guarded upgrade, and makes `completeChore` atomically increment the balance and record the completion in one transaction. `deleteChild`'s cascade now also removes a child's completions. Drops `Payout.childName` (#37): `deleteChild` already cascades payouts, so the snapshot never outlived its source and only risked desyncing from a future rename feature. `HistoryPage` now resolves the display name by joining `payout.childId` against the children list. `TotalsPage` and `HomePage` regain real "N chores completed" / "N done" captions, derived from the completions ledger instead of estimated off `totalCents`.
- **feat(safety)** (`f380dfa`): import now shows an `AlertDialog` naming the exact scope ("Replace 2 children, 24 chores and 15 payouts?") before touching the database when there's existing data, and confirming auto-downloads a backup of the current data first (reusing the export path). A genuinely empty database skips both. Chore completion's success toast now carries an Undo action; undoing atomically deletes the completion and gives back its value, refusing with a clear toast if a payout has already dropped the balance below it.
- **feat(pin)** (`2682027`): optional 4-6 digit parent PIN, stored only as a salted SHA-256 hash (WebCrypto) - kid-proofing, not cryptography, and the code says so. Gates Pay Out (both entry points), chore edit/delete, child delete, and import. Verifying a PIN grants a 5-minute in-memory grace window (not persisted). Adding children, adding chores and completing chores stay open to kids per the owner's decision. No PIN set = every gated action behaves exactly as before.
- **test** (`ea93866`): extends the vitest suite for all three feature commits (completions, cascade, undo including the refuse-when-balance-too-low case, legacy-backup import, PIN hashing/grace helpers, import-scope helper), adds a dedicated v2->v3 IndexedDB migration test built from raw `indexedDB` calls independent of `db.ts`, and extends the Playwright journey with a second PIN-gating scenario.

Closes #34
Closes #72
Closes #40
Closes #37

## Verification

All run from a clean `pnpm install`:

```
$ pnpm run check
$ tsc
(clean, no output)

$ pnpm run test
 ✓ tests/unit/import-scope.test.ts (5 tests)
 ✓ tests/unit/pin.test.ts (8 tests)
 ✓ tests/unit/schema.test.ts (10 tests)
 ✓ tests/unit/db-migration.test.ts (1 test)
 ✓ tests/unit/storage.test.ts (18 tests)
 Test Files  5 passed (5)
      Tests  42 passed (42)

$ pnpm run test:e2e
 ✓ add a child, complete a chore, pay out, and see it in history (2.3s)
 ✓ setting a parent PIN gates Pay Out until the PIN is entered (3.0s)
 2 passed (5.5s)
```

The migration test (`tests/unit/db-migration.test.ts`) opens a v2-shaped database with real data using raw `indexedDB` calls (independent of our own `db.ts`), reopens it through `getDB()` to trigger the v2->v3 upgrade, and confirms every existing store's data survived while the new completions store is not just present but readable and writable afterwards.

Confirmed `server/` and `.github/` are untouched: `git diff --stat main...feat/client-bundle -- server .github` produces no output.

## Judgement calls / deviations from the brief

- **Import "empty database" check** treats empty as children, chores AND payouts all zero. In practice this only fires in tests, because default chores auto-seed on first `getDB()` call, so a real first-time user's chores store is never actually empty. Implemented literally as specified rather than special-casing default/unmodified chores.
- **Extracted two small new `client/src/lib/*` helpers** (`pin.ts`, `import-scope.ts`) beyond the three lib files the brief named, since PIN hashing and the scope-naming logic needed a home and are more testable as pure functions than inlined in page components.
- **PIN gating is button-level, not handler-level**: the guard wraps the `onClick` that opens a dialog or triggers the destructive action, not the underlying handler function itself, so the handlers stay plain and directly testable if ever needed outside a gated context.
- **Playwright**: kept the original happy-path journey PIN-free on purpose (it doubles as the "no PIN set = ungated" control) and added a second scenario for the PIN-gated path, since the added testids made it cheap.