### PR TITLE
fix(pwa): install button appears again (module-scope beforeinstallprompt capture)

### DIFF
--- a/client/src/components/PWAInstallButton.tsx
+++ b/client/src/components/PWAInstallButton.tsx
@@ -1,6 +1,11 @@
 import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
-import { Download, Smartphone, X } from 'lucide-react';
+import { Smartphone, X } from 'lucide-react';
+import {
+  subscribeInstallPrompt,
+  promptInstall,
+  type BeforeInstallPromptEvent,
+} from '@/lib/pwa-install';
 import {
   Dialog,
   DialogContent,
@@ -8,15 +13,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-
-interface BeforeInstallPromptEvent extends Event {
-  readonly platforms: string[];
-  readonly userChoice: Promise<{
-    outcome: 'accepted' | 'dismissed';
-    platform: string;
-  }>;
-  prompt(): Promise<void>;
-}
 
 const STORAGE_KEYS = {
   DISMISSED: 'pwa-install-dismissed',
@@ -70,30 +66,22 @@ export default function PWAInstallButton() {
       setIsInstallable(true);
     }
 
-    // Listen for the beforeinstallprompt event (Chrome, Edge, etc.)
-    const handleBeforeInstallPrompt = (e: Event) => {
-      e.preventDefault();
-      const beforeInstallPromptEvent = e as BeforeInstallPromptEvent;
-      setDeferredPrompt(beforeInstallPromptEvent);
-      setIsInstallable(true);
-    };
+    // The beforeinstallprompt event is captured at module scope in
+    // lib/pwa-install.ts (armed before React renders); subscribing replays
+    // whatever was captured before this component mounted, which is the
+    // whole fix for the button never appearing: the event usually fires
+    // long before the dashboard exists.
+    const unsubscribe = subscribeInstallPrompt((event) => {
+      setDeferredPrompt(event);
+      if (event) {
+        setIsInstallable(true);
+      } else {
+        // Cleared by lib on appinstalled or after prompting.
+        setIsInstallable(isIOSDevice);
+      }
+    });
 
-    // Listen for successful installation
-    const handleAppInstalled = () => {
-      setIsInstalled(true);
-      setIsInstallable(false);
-      setDeferredPrompt(null);
-      localStorage.removeItem(STORAGE_KEYS.DISMISSED);
-      localStorage.removeItem(STORAGE_KEYS.REMIND_LATER);
-    };
-
-    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
-    window.addEventListener('appinstalled', handleAppInstalled);
-
-    return () => {
-      window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
-      window.removeEventListener('appinstalled', handleAppInstalled);
-    };
+    return unsubscribe;
   }, []);
 
   const handleInstallClick = async () => {
@@ -107,22 +95,11 @@ export default function PWAInstallButton() {
     if (!deferredPrompt) return;
 
     try {
-      // Show the install prompt
-      await deferredPrompt.prompt();
-
-      // Wait for the user's response
-      const choiceResult = await deferredPrompt.userChoice;
-
-      if (choiceResult.outcome === 'accepted') {
-        console.log('User accepted the install prompt');
+      const outcome = await promptInstall();
+      if (outcome === 'accepted') {
         localStorage.setItem(STORAGE_KEYS.LAST_SHOWN, new Date().toISOString());
-      } else {
-        console.log('User dismissed the install prompt');
+        setIsInstalled(true);
       }
-
-      // Clear the prompt
-      setDeferredPrompt(null);
-      setIsInstallable(false);
     } catch (error) {
       console.error('Error during installation:', error);
     }

--- a/client/src/lib/pwa-install.ts
+++ b/client/src/lib/pwa-install.ts
@@ -1,0 +1,71 @@
+// Captures Chrome's beforeinstallprompt at module scope, the moment the
+// bundle executes, because the event fires once and early: a listener
+// attached later inside a React useEffect loses the race whenever Chrome
+// evaluates installability before the component mounts (and on a first
+// visit the FirstRunPage replaces the layout, so the install button is
+// not mounted at all). This module is imported for its side effect from
+// main.tsx, ahead of React rendering; the event is stashed here and
+// handed to whichever component subscribes, whenever it mounts.
+
+export interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[];
+  readonly userChoice: Promise<{
+    outcome: 'accepted' | 'dismissed';
+    platform: string;
+  }>;
+  prompt(): Promise<void>;
+}
+
+type Listener = (event: BeforeInstallPromptEvent | null) => void;
+
+let deferredPrompt: BeforeInstallPromptEvent | null = null;
+const listeners = new Set<Listener>();
+
+function notify() {
+  listeners.forEach((listener) => listener(deferredPrompt));
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('beforeinstallprompt', (e) => {
+    // preventDefault suppresses Chrome's own mini-infobar so the in-app
+    // button is the single, deliberate install entry point.
+    e.preventDefault();
+    deferredPrompt = e as BeforeInstallPromptEvent;
+    notify();
+  });
+
+  window.addEventListener('appinstalled', () => {
+    deferredPrompt = null;
+    notify();
+  });
+}
+
+// Returns whatever has been captured so far (null if Chrome has not
+// offered installation, or the app is already installed).
+export function getDeferredPrompt(): BeforeInstallPromptEvent | null {
+  return deferredPrompt;
+}
+
+// Subscribe to future changes; immediately replays the current state so a
+// late-mounting component still sees an event captured before it existed.
+export function subscribeInstallPrompt(listener: Listener): () => void {
+  listeners.add(listener);
+  listener(deferredPrompt);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+// Consumes the stored event to show the browser's install dialog.
+export async function promptInstall(): Promise<'accepted' | 'dismissed' | 'unavailable'> {
+  if (!deferredPrompt) {
+    return 'unavailable';
+  }
+  const event = deferredPrompt;
+  await event.prompt();
+  const choice = await event.userChoice;
+  // The event is single-use regardless of outcome.
+  deferredPrompt = null;
+  notify();
+  return choice.outcome;
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,3 +1,7 @@
+// Side-effect import FIRST: arms the beforeinstallprompt capture before
+// React renders, so the install button can't lose the race to Chrome's
+// one-shot event (see client/src/lib/pwa-install.ts).
+import './lib/pwa-install';
 import { StrictMode } from 'react';
 import { createRoot } from "react-dom/client";
 import App from "./App";

--- a/tests/unit/pwa-install.test.ts
+++ b/tests/unit/pwa-install.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// The module arms a window listener at import time, which is the behaviour
+// under test, so each test gets a fresh module registry and a fresh fake
+// window installed BEFORE the import happens.
+
+type PromptOutcome = { outcome: 'accepted' | 'dismissed'; platform: string };
+
+function makeFakeWindow() {
+  const handlers = new Map<string, Set<(e: Event) => void>>();
+  return {
+    addEventListener(type: string, handler: (e: Event) => void) {
+      if (!handlers.has(type)) handlers.set(type, new Set());
+      handlers.get(type)!.add(handler);
+    },
+    removeEventListener(type: string, handler: (e: Event) => void) {
+      handlers.get(type)?.delete(handler);
+    },
+    dispatch(type: string, event: Event) {
+      handlers.get(type)?.forEach((h) => h(event));
+    },
+  };
+}
+
+function makeInstallEvent(outcome: PromptOutcome['outcome'] = 'accepted') {
+  const event = new Event('beforeinstallprompt') as Event & {
+    platforms: string[];
+    userChoice: Promise<PromptOutcome>;
+    prompt: () => Promise<void>;
+  };
+  Object.assign(event, {
+    platforms: ['web'],
+    userChoice: Promise.resolve({ outcome, platform: 'web' }),
+    prompt: vi.fn().mockResolvedValue(undefined),
+  });
+  return event;
+}
+
+async function importFreshModule(fakeWindow: ReturnType<typeof makeFakeWindow>) {
+  vi.resetModules();
+  vi.stubGlobal('window', fakeWindow);
+  return import('@/lib/pwa-install');
+}
+
+describe('pwa-install capture store', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('delivers an event captured BEFORE any subscriber existed (the missed-race fix)', async () => {
+    const fakeWindow = makeFakeWindow();
+    const mod = await importFreshModule(fakeWindow);
+
+    // Event fires while no component is mounted, as on a real first load.
+    const event = makeInstallEvent();
+    fakeWindow.dispatch('beforeinstallprompt', event);
+
+    // A component mounting later still receives it via replay.
+    const seen: (Event | null)[] = [];
+    mod.subscribeInstallPrompt((e) => seen.push(e));
+    expect(seen).toEqual([event]);
+    expect(mod.getDeferredPrompt()).toBe(event);
+  });
+
+  it('notifies an existing subscriber when the event arrives later', async () => {
+    const fakeWindow = makeFakeWindow();
+    const mod = await importFreshModule(fakeWindow);
+
+    const seen: (Event | null)[] = [];
+    mod.subscribeInstallPrompt((e) => seen.push(e));
+    expect(seen).toEqual([null]);
+
+    const event = makeInstallEvent();
+    fakeWindow.dispatch('beforeinstallprompt', event);
+    expect(seen).toEqual([null, event]);
+  });
+
+  it('promptInstall consumes the event and reports the outcome', async () => {
+    const fakeWindow = makeFakeWindow();
+    const mod = await importFreshModule(fakeWindow);
+
+    fakeWindow.dispatch('beforeinstallprompt', makeInstallEvent('accepted'));
+    expect(await mod.promptInstall()).toBe('accepted');
+    expect(mod.getDeferredPrompt()).toBeNull();
+    expect(await mod.promptInstall()).toBe('unavailable');
+  });
+
+  it('clears the stored event on appinstalled', async () => {
+    const fakeWindow = makeFakeWindow();
+    const mod = await importFreshModule(fakeWindow);
+
+    fakeWindow.dispatch('beforeinstallprompt', makeInstallEvent());
+    expect(mod.getDeferredPrompt()).not.toBeNull();
+
+    fakeWindow.dispatch('appinstalled', new Event('appinstalled'));
+    expect(mod.getDeferredPrompt()).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #105

Chrome fires beforeinstallprompt once, early in page load. PWAInstallButton attached its listener inside useEffect, losing the race whenever the event preceded React mounting, and on a first visit FirstRunPage replaces the entire layout so the component was never mounted during exactly the visit Chrome evaluates. Users therefore had no visible way to discover installation.

- client/src/lib/pwa-install.ts: module-scope capture armed by a side-effect import at the very top of main.tsx; stores the one-shot event, replays it to any later subscriber, exposes promptInstall() consuming it, clears on appinstalled.
- PWAInstallButton now subscribes to the store instead of racing the event; iOS path unchanged.
- 4 unit tests, the first being the regression case: an event dispatched before any subscriber exists is delivered on subscribe.

Verification: pnpm run check clean, pnpm run test 46/46 (6 files). Real-phone confirmation after deploy: load candr.lunt.au fresh in Chrome, the Install App button should appear on the dashboard.