### PR TITLE
feat(ui): install button sized to match Add Child, with a soft pulse

### DIFF
--- a/client/src/components/PWAInstallButton.tsx
+++ b/client/src/components/PWAInstallButton.tsx
@@ -150,10 +150,15 @@ export default function PWAInstallButton() {
   return (
     <>
       <div className="relative inline-block">
+        {/* Same structural sizing as the Add Child button beside it (default
+            Button size, same horizontal padding), so the pair reads as
+            equals; the dismiss control floats as a corner badge instead of
+            padding the button wider. The pulse-ring draws the eye without
+            the flicker of an opacity pulse. */}
         <Button
           onClick={handleInstallClick}
           variant="outline"
-          className="bg-white border-brand-coral text-brand-coral hover:bg-brand-coral hover:text-white transition-all shadow-soft pr-10"
+          className="bg-white border-brand-coral text-brand-coral hover:bg-brand-coral hover:text-white transition-all shadow-soft animate-pulse-ring"
           data-testid="button-install-pwa"
         >
           <Smartphone className="w-4 h-4 mr-2" />
@@ -161,7 +166,7 @@ export default function PWAInstallButton() {
         </Button>
         <button
           onClick={handleRemindLater}
-          className="absolute right-1 top-1/2 -translate-y-1/2 p-1 hover:bg-brand-coral/10 rounded transition-colors"
+          className="absolute -top-1.5 -right-1.5 p-0.5 bg-white border border-brand-coral/40 rounded-full shadow-soft hover:bg-brand-coral/10 transition-colors"
           aria-label="Remind me later"
           data-testid="button-remind-later"
         >

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -87,10 +87,17 @@ export default {
             height: "0",
           },
         },
+        // Soft attention pulse for the PWA install button: a coral ring
+        // breathing outward, gentler than Tailwind's opacity pulse.
+        "pulse-ring": {
+          "0%, 100%": { boxShadow: "0 0 0 0 rgba(244, 63, 94, 0.35)" },
+          "50%": { boxShadow: "0 0 0 8px rgba(244, 63, 94, 0)" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        "pulse-ring": "pulse-ring 2.4s ease-in-out infinite",
       },
     },
   },


### PR DESCRIPTION
Follow-up to #105 after real-phone feedback: the install button existed but was easy to miss and sat visually unequal to Add Child.

- New pulse-ring keyframe (coral ring breathing outward, 2.4s) on the install button: attention without opacity flicker.
- Structural sizing now identical to Add Child (default Button size and padding); the remind-later X floats as a corner badge instead of widening the button with pr-10.
- The pair sits in the existing flex row, so when only Add Child renders its appearance and position are exactly as before (its own classes are untouched).

Verified: tsc clean, 46/46 unit tests, build contains the animation class.