### PR TITLE
ci: check every pull request, not only those targeting main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - main
+  # Deliberately unfiltered: every pull request is checked, whatever it targets.
+  # With `branches: [main]` here, a PR stacked on another branch ran no checks
+  # at all, and GitHub still reported it mergeable with mergeStateStatus CLEAN
+  # and an empty statusCheckRollup. Not a missing check that looks missing, a
+  # missing check that looks like a pass. The push trigger stays main-only:
+  # this only needs to widen for pull requests.
   pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
One line per workflow: drop the `branches` filter from the `pull_request` trigger.

## Why

A PR whose base is any branch other than `main` matched no trigger, so it ran **no checks at all**. GitHub does not present that as unchecked. Measured on `engineering-audit#279` before the same fix landed there:

```
base=docs/realistic-demo-screenshots  mergeable=MERGEABLE  state=CLEAN  checks=0
```

`CLEAN` and mergeable with zero checks ever having run. It reads exactly like a PR that passed, so merging on that basis ships untested code while believing CI cleared it. Not a missing check that looks missing, a missing check that looks like a pass.

## Scope of the change

- `push` stays `branches: [main]`. Unfiltering that too would run the suite on every branch push, duplicating the run the branch's own PR is about to do.
- This only **adds** runs for PRs targeting a non-main base, which are rare, so the Actions-minutes cost is close to nil. It does not make CI run more often on ordinary PRs.
- Verified by parsing each file before and after: the `pull_request` filter is gone, the `push` trigger is byte-identical, and nothing outside the trigger block changed.